### PR TITLE
Fix unhandled exceptions in drop-in monitor

### DIFF
--- a/src/modules/dropins/Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs
+++ b/src/modules/dropins/Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs
@@ -67,7 +67,14 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
         if (task == null)
             return;
 
-        await task;
+        try
+        {
+            await task;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing change for path {Path}", e.FullPath);
+        }
     }
 
     private async void OnDeleted(object sender, FileSystemEventArgs e)
@@ -77,7 +84,14 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
         if (task == null)
             return;
 
-        await task;
+        try
+        {
+            await task;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing delete for path {Path}", e.FullPath);
+        }
     }
 
     private async Task LoadDropInAssemblyAsync(string fullPath)


### PR DESCRIPTION
## Summary
- add error handling around asynchronous filesystem events
- ensure DropIn monitor file ends with newline

---
https://chatgpt.com/codex/tasks/task_e_684673c97470832ab75333d89951cac6