### PR TITLE
Implementing KernelFactory interface in order to allow custom factories + Using SK function that supports external tools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
-    <PackageVersion Include="Elsa" Version="$(ElsaVersion)" />
+    <PackageVersion Include="Elsa" Version="3.4.0" />
     <PackageVersion Include="Elsa.Api.Common" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Common" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Caching" Version="$(ElsaVersion)" />
@@ -38,6 +38,7 @@
     <PackageVersion Include="Elsa.Workflows.Management" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Workflows.Runtime" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Workflows.Runtime.Distributed" Version="$(ElsaVersion)" />
+    <PackageVersion Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.59.0" />
   </ItemGroup>
   <ItemGroup Label="Elsa Studio">
     <PackageVersion Include="Elsa.Studio" Version="$(ElsaStudioVersion)" />
@@ -45,7 +46,7 @@
     <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="$(ElsaStudioVersion)" />
     <PackageVersion Include="Elsa.Studio.Shared" Version="$(ElsaStudioVersion)" />
     <PackageVersion Include="Elsa.Studio.Workflows" Version="$(ElsaStudioVersion)" />
-    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="$(ElsaStudioVersion)"/>
+    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="$(ElsaStudioVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Elsa">
-    <PackageVersion Include="Elsa" Version="3.4.0" />
+    <PackageVersion Include="Elsa" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Api.Common" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Common" Version="$(ElsaVersion)" />
     <PackageVersion Include="Elsa.Caching" Version="$(ElsaVersion)" />

--- a/src/modules/agents/Elsa.Agents.Activities/Activities/AgentActivity.cs
+++ b/src/modules/agents/Elsa.Agents.Activities/Activities/AgentActivity.cs
@@ -47,7 +47,11 @@ public class AgentActivity : CodeActivity
 
         var agentInvoker = context.GetRequiredService<AgentInvoker>();
         var result = await agentInvoker.InvokeAgentAsync(AgentName, functionInput, context.CancellationToken);
-        var json = result.FunctionResult.GetValue<string>();
+        var json = result.ChatMessageContent.Content?.Trim();
+
+        if (string.IsNullOrWhiteSpace(json))
+            throw new InvalidOperationException("The message content is empty or null.");
+
         var outputType = context.ActivityDescriptor.Outputs.Single().Type;
 
         // If the target type is object, we want the JSON to be deserialized into an ExpandoObject for dynamic field access. 

--- a/src/modules/agents/Elsa.Agents.Activities/Elsa.Agents.Activities.csproj
+++ b/src/modules/agents/Elsa.Agents.Activities/Elsa.Agents.Activities.csproj
@@ -3,7 +3,8 @@
     <PropertyGroup>
         <Description>Provides Agent activities</Description>
         <PackageTags>elsa extension module agents semantic kernel llm ai</PackageTags>
-    </PropertyGroup>
+		<Version> 3.4.0</Version>
+	</PropertyGroup>
     
     <ItemGroup>
         <PackageReference Include="Elsa" />

--- a/src/modules/agents/Elsa.Agents.Activities/Elsa.Agents.Activities.csproj
+++ b/src/modules/agents/Elsa.Agents.Activities/Elsa.Agents.Activities.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <Description>Provides Agent activities</Description>
         <PackageTags>elsa extension module agents semantic kernel llm ai</PackageTags>
-		<Version> 3.4.0</Version>
 	</PropertyGroup>
     
     <ItemGroup>

--- a/src/modules/agents/Elsa.Agents.Core/Contracts/IkernelFactory.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Contracts/IkernelFactory.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.SemanticKernel;
+namespace Elsa.Agents.Contracts;
+
+public interface IKernelFactory
+{
+    Kernel CreateKernel(KernelConfig kernelConfig, AgentConfig agentConfig);
+    Kernel CreateKernel(KernelConfig kernelConfig, string agentName);
+}

--- a/src/modules/agents/Elsa.Agents.Core/Contracts/IkernelFactory.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Contracts/IkernelFactory.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.SemanticKernel;
-namespace Elsa.Agents.Contracts;
+namespace Elsa.Agents;
 
 public interface IKernelFactory
 {

--- a/src/modules/agents/Elsa.Agents.Core/Elsa.Agents.Core.csproj
+++ b/src/modules/agents/Elsa.Agents.Core/Elsa.Agents.Core.csproj
@@ -4,7 +4,6 @@
         <Description>Provides an agentic framework using Semantic Kernel</Description>
         <PackageTags>elsa extension module agents semantic kernel llm ai</PackageTags>
         <RootNamespace>Elsa.Agents</RootNamespace>
-		<Version> 4.444.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/modules/agents/Elsa.Agents.Core/Elsa.Agents.Core.csproj
+++ b/src/modules/agents/Elsa.Agents.Core/Elsa.Agents.Core.csproj
@@ -4,6 +4,7 @@
         <Description>Provides an agentic framework using Semantic Kernel</Description>
         <PackageTags>elsa extension module agents semantic kernel llm ai</PackageTags>
         <RootNamespace>Elsa.Agents</RootNamespace>
+		<Version> 4.444.0</Version>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,6 +13,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
         <PackageReference Include="Microsoft.SemanticKernel" />
+        <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/agents/Elsa.Agents.Core/Extensions/AgentConfigExtensions.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Extensions/AgentConfigExtensions.cs
@@ -20,6 +20,7 @@ public static class AgentConfigExtensions
             ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
             ResponseFormat = agentConfig.ExecutionSettings.ResponseFormat,
             ChatSystemPrompt = agentConfig.PromptTemplate,
+            ServiceId = "default"
         };
     }
 

--- a/src/modules/agents/Elsa.Agents.Core/Extensions/FunctionResultExtensions.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Extensions/FunctionResultExtensions.cs
@@ -8,18 +8,24 @@ public static class FunctionResultExtensions
     public static async Task<JsonElement> AsJsonElementAsync(this Task<InvokeAgentResult> resultTask)
     {
         var result = await resultTask;
-        return result.FunctionResult.AsJsonElement();
+        return result.ChatMessageContent.AsJsonElement();
     }
-    
-    public static async Task<JsonElement> AsJsonElementAsync(this Task<FunctionResult> resultTask)
+
+    public static JsonElement AsJsonElement(this ChatMessageContent result)
     {
-        var result = await resultTask;
-        return result.AsJsonElement();
-    }
-    
-    public static JsonElement AsJsonElement(this FunctionResult result)
-    {
-        var response = result.GetValue<string>()!;
-        return JsonSerializer.Deserialize<JsonElement>(response);
+        var content = result.Content?.Trim();
+
+        if (string.IsNullOrWhiteSpace(content))
+            throw new InvalidOperationException("The message content is empty.");
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(content!);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Error deserializing the message content as JSON:\n{content}", ex);
+        }
+
     }
 }

--- a/src/modules/agents/Elsa.Agents.Core/Models/InvokeAgentResult.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Models/InvokeAgentResult.cs
@@ -3,12 +3,8 @@ using Microsoft.SemanticKernel;
 
 namespace Elsa.Agents;
 
-public record InvokeAgentResult(AgentConfig Function, FunctionResult FunctionResult)
+public record InvokeAgentResult(AgentConfig Function, ChatMessageContent ChatMessageContent)
 {
-    public object? ParseResult()
-    {
-        var targetType = Type.GetType(Function.OutputVariable.Type) ?? typeof(JsonElement);
-        var json = FunctionResult.GetValue<string>();
-        return JsonSerializer.Deserialize(json, targetType);
-    }
+
+
 }

--- a/src/modules/agents/Elsa.Agents.Core/Services/AgentInvoker.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Services/AgentInvoker.cs
@@ -51,14 +51,14 @@ public class AgentInvoker(IKernelFactory kernelFactory, IKernelConfigProvider ke
 
         var templateFactory = new HandlebarsPromptTemplateFactory();
 
-        var manolo = new PromptTemplateConfig
+        var promptConfig = new PromptTemplateConfig
         {
             Template = agentConfig.PromptTemplate,
             TemplateFormat = "handlebars",
             Name = agentConfig.FunctionName
         };
 
-        var promptTemplate = templateFactory.Create(manolo);
+        var promptTemplate = templateFactory.Create(promptConfig);
 
         var kernelArguments = new KernelArguments(input);
         string renderedPrompt = await promptTemplate.RenderAsync(kernel, kernelArguments);

--- a/src/modules/agents/Elsa.Agents.Core/Services/AgentInvoker.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Services/AgentInvoker.cs
@@ -1,12 +1,14 @@
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.SemanticKernel.PromptTemplates.Handlebars;
 
 #pragma warning disable SKEXP0010
 #pragma warning disable SKEXP0001
 
 namespace Elsa.Agents;
 
-public class AgentInvoker(KernelFactory kernelFactory, IKernelConfigProvider kernelConfigProvider)
+public class AgentInvoker(IKernelFactory kernelFactory, IKernelConfigProvider kernelConfigProvider)
 {
     public async Task<InvokeAgentResult> InvokeAgentAsync(string agentName, IDictionary<string, object?> input, CancellationToken cancellationToken = default)
     {
@@ -21,9 +23,9 @@ public class AgentInvoker(KernelFactory kernelFactory, IKernelConfigProvider ker
             MaxTokens = executionSettings.MaxTokens,
             PresencePenalty = executionSettings.PresencePenalty,
             FrequencyPenalty = executionSettings.FrequencyPenalty,
-            ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
             ResponseFormat = executionSettings.ResponseFormat,
             ChatSystemPrompt = agentConfig.PromptTemplate,
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
         };
         
         var promptExecutionSettingsDictionary = new Dictionary<string, PromptExecutionSettings>
@@ -46,10 +48,36 @@ public class AgentInvoker(KernelFactory kernelFactory, IKernelConfigProvider ker
                 AllowDangerouslySetContent = true
             }).ToList()
         };
-        
-        var kernelFunction = kernel.CreateFunctionFromPrompt(promptTemplateConfig);
+
+        var templateFactory = new HandlebarsPromptTemplateFactory();
+
+        var manolo = new PromptTemplateConfig
+        {
+            Template = agentConfig.PromptTemplate,
+            TemplateFormat = "handlebars",
+            Name = agentConfig.FunctionName
+        };
+
+        var promptTemplate = templateFactory.Create(manolo);
+
         var kernelArguments = new KernelArguments(input);
-        var result = await kernelFunction.InvokeAsync(kernel, kernelArguments, cancellationToken: cancellationToken);
-        return new(agentConfig, result);
+        string renderedPrompt = await promptTemplate.RenderAsync(kernel, kernelArguments);
+
+        ChatHistory chatHistory = [];
+        chatHistory.AddUserMessage(renderedPrompt);
+
+        IChatCompletionService chatCompletion = kernel.GetRequiredService<IChatCompletionService>();
+
+        OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
+        {
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+        };
+
+        var response = await chatCompletion.GetChatMessageContentAsync(
+            chatHistory,
+            executionSettings: openAIPromptExecutionSettings,
+            kernel: kernel);
+
+        return new(agentConfig, response);
     }
 }

--- a/src/modules/agents/Elsa.Agents.Core/Services/KernelFactory.cs
+++ b/src/modules/agents/Elsa.Agents.Core/Services/KernelFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel;
 
 namespace Elsa.Agents;
 
-public class KernelFactory(IPluginDiscoverer pluginDiscoverer, IServiceDiscoverer serviceDiscoverer, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, ILogger<KernelFactory> logger)
+public class KernelFactory(IPluginDiscoverer pluginDiscoverer, IServiceDiscoverer serviceDiscoverer, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, ILogger<KernelFactory> logger) : IKernelFactory
 {
     public Kernel CreateKernel(KernelConfig kernelConfig, string agentName)
     {


### PR DESCRIPTION
It should be possible to modify the kernel factory through the interface in order to access the Kernel or change the public implementations.

To give an example, in my case I'm currently trying to implement MCP servers in Elsa. This will take time and requires modifying many parts of the agents folder. It’s very likely that I’ll submit a PR so Elsa can support it natively, but I should be able to use my implementation through yours NuGets without needing to implement it directly in the repository.

Right now, I'm unable to implement my code properly without access to the kernel instantiated by the KernelFactory.

Furthermore, the current function used to send the request to the AI is creating a Semantic Kernel tool that renders the prompt, and then sends the result of this toot, that is, the already rendered prompt, to the AI as a query. 

This method prevents loading your own external tools, such as tools from an external MCP server. 

I used a Semantic Kernel NuGet package to access the engine that renders the prompt, and I render it separately just like the original function does. Then I call ChatCompletion, which is the standard method to interact with the AI and allows the use of external tools. 

It also lets you manage a ChatHistory to retain the conversation context if desired. This way, it is indeed possible to use external tools in Elsa. 

There is a more advanced SK method specialized for agents, but for now, I think this is the most viable option. Currently, without this approach, external tools cannot be used. 

It’s worth noting that in Elsa Studio, the format of the prompt structure and its variables is practically the same, except you no longer need to use the $, so if you have a variable named variable1, you would write {{variable1}}. 

It’s literally using the same engine that renders this in the original function, the difference is that it has been customized and uses the $ for invoking internal Semantic functions, which is now deprecated. Normally, you should use an MCP.

