### PR TITLE
Refactor database extensions and support migrations for V3.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <UseProjectReferences>false</UseProjectReferences>
+        <UseProjectReferences>true</UseProjectReferences>
     </PropertyGroup>
     <PropertyGroup>
         <Authors>Elsa Workflows Community</Authors>

--- a/src/modules/agents/Elsa.Studio.Agents/Elsa.Studio.Agents.csproj
+++ b/src/modules/agents/Elsa.Studio.Agents/Elsa.Studio.Agents.csproj
@@ -3,13 +3,14 @@
     <PropertyGroup>
         <Description>Provides a UI for managing agents.</Description>
         <PackageTags>elsa extension studio module agent ai llm semantic kernel</PackageTags>
+        <UseProjectReferences>true</UseProjectReferences>
     </PropertyGroup>
 
-    <ItemGroup Label="Elsa" Condition="'$(UseProjectReferences)' == 'true'">
+    <ItemGroup Label="Elsa" Condition="$(UseProjectReferences) == true">
         <ProjectReference Include="..\..\..\..\..\..\client\studio\src\modules\Elsa.Studio.Workflows\Elsa.Studio.Workflows.csproj" />
     </ItemGroup>
     
-    <ItemGroup Label="Elsa" Condition="'$(UseProjectReferences)' != 'true'">
+    <ItemGroup Label="Elsa" Condition="$(UseProjectReferences) != true">
       <PackageReference Include="Elsa.Studio.Workflows" />
     </ItemGroup>
 

--- a/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowDefinitionStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowDefinitionStore.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Elsa.Common.Entities;
 using Elsa.Common.Models;
 using Elsa.Persistence.Dapper.Extensions;

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Common/Abstractions/DesignTimeDbContextFactoryBase.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Common/Abstractions/DesignTimeDbContextFactoryBase.cs
@@ -23,11 +23,18 @@ public abstract class DesignTimeDbContextFactoryBase<TDbContext> : IDesignTimeDb
         var parser = new Parser(command);
         var parseResult = parser.Parse(args);
         var connectionString = parseResult.GetValueForOption(connectionStringOption) ?? "Data Source=local";
-        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var services = new ServiceCollection();
 
+        ConfigureServices(services);
         ConfigureBuilder(builder, connectionString);
 
+        var serviceProvider = services.BuildServiceProvider();
         return (TDbContext)ActivatorUtilities.CreateInstance(serviceProvider, typeof(TDbContext), builder.Options);
+    }
+    
+    protected virtual void ConfigureServices(IServiceCollection services) 
+    {
+        // This method can be overridden to configure additional services if needed.
     }
 
     /// <summary>

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Common/Elsa.Persistence.EFCore.Common.csproj
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Common/Elsa.Persistence.EFCore.Common.csproj
@@ -5,7 +5,6 @@
             Provides common Entity Framework Core types for implementing EF Core persistence of varipus ELsa modules.
         </Description>
         <PackageTags>elsa extension module persistence efcore</PackageTags>
-        <RootNamespace>Elsa.EFCore</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Common/ElsaDbContextBase.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Common/ElsaDbContextBase.cs
@@ -19,7 +19,7 @@ public abstract class ElsaDbContextBase : DbContext, IElsaDbContextSchema
     };
 
     protected IServiceProvider ServiceProvider { get; }
-    private readonly ElsaDbContextOptions? elsaDbContextOptions;
+    private readonly ElsaDbContextOptions? _elsaDbContextOptions;
     public string? TenantId { get; set; }
 
     /// <summary>
@@ -41,10 +41,10 @@ public abstract class ElsaDbContextBase : DbContext, IElsaDbContextSchema
     protected ElsaDbContextBase(DbContextOptions options, IServiceProvider serviceProvider) : base(options)
     {
         ServiceProvider = serviceProvider;
-        elsaDbContextOptions = options.FindExtension<ElsaDbContextOptionsExtension>()?.Options;
+        _elsaDbContextOptions = options.FindExtension<ElsaDbContextOptionsExtension>()?.Options;
 
         // ReSharper disable once VirtualMemberCallInConstructor
-        Schema = !string.IsNullOrWhiteSpace(elsaDbContextOptions?.SchemaName) ? elsaDbContextOptions.SchemaName : ElsaSchema;
+        Schema = !string.IsNullOrWhiteSpace(_elsaDbContextOptions?.SchemaName) ? _elsaDbContextOptions.SchemaName : ElsaSchema;
 
         var tenantAccessor = serviceProvider.GetService<ITenantAccessor>();
         var tenantId = tenantAccessor?.Tenant?.Id;
@@ -66,7 +66,7 @@ public abstract class ElsaDbContextBase : DbContext, IElsaDbContextSchema
         if (!string.IsNullOrWhiteSpace(Schema))
             modelBuilder.HasDefaultSchema(Schema);
 
-        var additionalConfigurations = elsaDbContextOptions?.GetModelConfigurations(this);
+        var additionalConfigurations = _elsaDbContextOptions?.GetModelConfigurations(this);
 
         additionalConfigurations?.Invoke(modelBuilder);
 

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/DbContextFactories.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/DbContextFactories.cs
@@ -6,8 +6,10 @@ using Elsa.Persistence.EFCore.Modules.Labels;
 using Elsa.Persistence.EFCore.Modules.Management;
 using Elsa.Persistence.EFCore.Modules.Runtime;
 using Elsa.Persistence.EFCore.Modules.Tenants;
+using Elsa.Persistence.EFCore.MySql.Handlers;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -33,6 +35,11 @@ public class TenantsDbContextFactories : MySqlDesignTimeDbContextFactory<Tenants
 
 public class MySqlDesignTimeDbContextFactory<TDbContext> : DesignTimeDbContextFactoryBase<TDbContext> where TDbContext : DbContext
 {
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IEntityModelCreatingHandler, SetupForMySql>();
+    }
+
     protected override void ConfigureBuilder(DbContextOptionsBuilder<TDbContext> builder, string connectionString)
     {
         builder.UseElsaMySql(GetType().Assembly, connectionString, serverVersion: ServerVersion.Parse("9.0.0"));

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Handlers/SetupForMySql.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Handlers/SetupForMySql.cs
@@ -1,0 +1,27 @@
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Elsa.Persistence.EFCore.MySql.Handlers;
+
+/// <summary>
+/// Represents a class that handles entity model creation for SQLite databases.
+/// </summary>
+public class SetupForMySql : IEntityModelCreatingHandler
+{
+    /// <inheritdoc />
+    public void Handle(ElsaDbContextBase dbContext, ModelBuilder modelBuilder, IMutableEntityType entityType)
+    {
+        if (!dbContext.Database.IsMySql())
+            return;
+
+        // Configure the WorkflowDefinition entity to use the PostgreSQL JSONB type for the StringData property:
+        if (entityType.ClrType == typeof(WorkflowDefinition))
+        {
+            modelBuilder
+                .Entity(entityType.Name)
+                .Property("StringData")
+                .HasColumnType("JSON");
+        }
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Migrations/Management/20250711172853_V3_6.Designer.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Migrations/Management/20250711172853_V3_6.Designer.cs
@@ -3,86 +3,89 @@ using System;
 using Elsa.Persistence.EFCore.Modules.Management;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Oracle.EntityFrameworkCore.Metadata;
 
 #nullable disable
 
-namespace Elsa.Persistence.EFCore.Oracle.Migrations.Management
+namespace Elsa.Persistence.EFCore.MySql.Migrations.Management
 {
     [DbContext(typeof(ManagementElsaDbContext))]
-    partial class ManagementElsaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250711172853_V3_6")]
+    partial class V3_6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
                 .HasAnnotation("ProductVersion", "9.0.6")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-            OracleModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("Elsa.Workflows.Management.Entities.WorkflowDefinition", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<byte[]>("BinaryData")
-                        .HasColumnType("RAW(2000)");
+                        .HasColumnType("longblob");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IsLatest")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsReadonly")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsSystem")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("MaterializerContext")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MaterializerName")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ProviderName")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StringData")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("JSON");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ToolVersion")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool?>("UsableAsActivity")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -117,62 +120,62 @@ namespace Elsa.Persistence.EFCore.Oracle.Migrations.Management
             modelBuilder.Entity("Elsa.Workflows.Management.Entities.WorkflowInstance", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("CorrelationId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DataCompressionAlgorithm")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("DefinitionVersionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTimeOffset?>("FinishedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("IncidentCount")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.Property<bool>("IsExecuting")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsSystem")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ParentWorkflowInstanceId")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("SubStatus")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset>("UpdatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Migrations/Management/20250711172853_V3_6.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Migrations/Management/20250711172853_V3_6.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Elsa.Persistence.EFCore.MySql.Migrations.Management
+{
+    /// <inheritdoc />
+    public partial class V3_6 : Migration
+    {
+        private readonly Elsa.Persistence.EFCore.IElsaDbContextSchema _schema;
+
+        /// <inheritdoc />
+        public V3_6(Elsa.Persistence.EFCore.IElsaDbContextSchema schema)
+        {
+            _schema = schema;
+        }
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "StringData",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "JSON",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "StringData",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "JSON",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Migrations/Management/ManagementElsaDbContextModelSnapshot.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Migrations/Management/ManagementElsaDbContextModelSnapshot.cs
@@ -18,7 +18,7 @@ namespace Elsa.Persistence.EFCore.MySql.Migrations.Management
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
-                .HasAnnotation("ProductVersion", "8.0.12")
+                .HasAnnotation("ProductVersion", "9.0.6")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -70,7 +70,7 @@ namespace Elsa.Persistence.EFCore.MySql.Migrations.Management
                         .HasColumnType("longtext");
 
                     b.Property<string>("StringData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("JSON");
 
                     b.Property<string>("TenantId")
                         .HasColumnType("varchar(255)");

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/MySqlProvidersExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/MySqlProvidersExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Reflection;
+using Elsa.Extensions;
+using Elsa.Persistence.EFCore.MySql.Handlers;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 // ReSharper disable once CheckNamespace
@@ -53,6 +55,7 @@ public static class MySqlProvidersExtensions
         where TDbContext : ElsaDbContextBase
         where TFeature : PersistenceFeatureBase<TFeature, TDbContext>
     {
+        feature.Module.Services.TryAddScopedImplementation<IEntityModelCreatingHandler, SetupForMySql>();
         feature.DbContextOptionsBuilder = (sp, db) => db.UseElsaMySql(migrationsAssembly, connectionStringFunc(sp), options, configure: configure);
         return (TFeature)feature;
     }

--- a/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Services/MySqlWorkflowReferenceQuery.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.MySql/Services/MySqlWorkflowReferenceQuery.cs
@@ -1,0 +1,52 @@
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+using MySqlConnector;
+
+namespace Elsa.Persistence.EFCore.MySql.Services;
+
+/// <summary>
+/// Provides an implementation of <see cref="IWorkflowReferenceQuery"/> for querying MySQL databases
+/// to find all latest workflow definitions that reference a specific workflow definition.
+/// </summary>
+public class MySqlWorkflowReferenceQuery(IDbContextFactory<ManagementElsaDbContext> dbContextFactory) : IWorkflowReferenceQuery
+{
+    public async Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var tableName = dbContext.Model.FindEntityType(typeof(WorkflowDefinition))!.GetTableName();
+
+        var sql = $"""
+                     SELECT
+                     t.DefinitionId,
+                     t.TenantId
+                   FROM {tableName} AS t
+                   WHERE
+                     t.IsLatest = 1
+                     AND EXISTS (
+                       SELECT 1
+                       FROM {tableName} AS t2
+                       CROSS JOIN JSON_TABLE(
+                         t2.StringData,
+                         '$.activities[*]'
+                         COLUMNS (
+                           workflowDefinitionId            VARCHAR(255) PATH '$.workflowDefinitionId',
+                           latestAvailablePublishedVersion INT           PATH '$.latestAvailablePublishedVersion'
+                         )
+                       ) AS act
+                       WHERE
+                         t2.DefinitionId = t.DefinitionId
+                         AND act.workflowDefinitionId = @p0
+                         AND act.latestAvailablePublishedVersion IS NOT NULL
+                     )
+                   """;
+
+        var param = new MySqlParameter("@p0", workflowDefinitionId);
+
+        return await dbContext.Set<WorkflowDefinition>()
+            .FromSqlRaw(sql, param)
+            .Select(x => x.DefinitionId)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Configurations/Management.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Configurations/Management.cs
@@ -10,7 +10,7 @@ internal class Management : IEntityTypeConfiguration<WorkflowDefinition>, IEntit
     {
         // In order to use data more than 2000 char we have to use NCLOB.
         // In Oracle, we have to explicitly say the column is NCLOB otherwise it would be considered nvarchar(2000).
-        builder.Property<string>("StringData").HasColumnType("NCLOB");
+        builder.Property<string>("StringData").HasColumnType("JSON");
         builder.Property<string>("Data").HasColumnType("NCLOB");
         builder.Property(x => x.Description).HasColumnType("NCLOB");
         builder.Property(x => x.MaterializerContext).HasColumnType("NCLOB");

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/DbContextFactories.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/DbContextFactories.cs
@@ -35,7 +35,6 @@ public class OracleDesignTimeDbContextFactory<TDbContext> : DesignTimeDbContextF
 {
     protected override void ConfigureBuilder(DbContextOptionsBuilder<TDbContext> builder, string connectionString)
     {
-        var options = new ElsaDbContextOptions().Configure();
-        builder.UseElsaOracle(GetType().Assembly, connectionString, options);
+        builder.UseElsaOracle(GetType().Assembly, connectionString);
     }
 }

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Migrations/Management/20250711191819_V3_6.Designer.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Migrations/Management/20250711191819_V3_6.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Elsa.Persistence.EFCore.Modules.Management;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Oracle.EntityFrameworkCore.Metadata;
 
@@ -11,9 +12,11 @@ using Oracle.EntityFrameworkCore.Metadata;
 namespace Elsa.Persistence.EFCore.Oracle.Migrations.Management
 {
     [DbContext(typeof(ManagementElsaDbContext))]
-    partial class ManagementElsaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250711191819_V3_6")]
+    partial class V3_6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Migrations/Management/20250711191819_V3_6.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Migrations/Management/20250711191819_V3_6.cs
@@ -1,0 +1,146 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Elsa.Persistence.EFCore.Oracle.Migrations.Management
+{
+    /// <inheritdoc />
+    public partial class V3_6 : Migration
+    {
+        private readonly Elsa.Persistence.EFCore.IElsaDbContextSchema _schema;
+
+        /// <inheritdoc />
+        public V3_6(Elsa.Persistence.EFCore.IElsaDbContextSchema schema)
+        {
+            _schema = schema;
+        }
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Data",
+                schema: _schema.Schema,
+                table: "WorkflowInstances",
+                type: "NVARCHAR2(2000)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NCLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StringData",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NVARCHAR2(2000)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NCLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MaterializerContext",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NVARCHAR2(2000)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NCLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NVARCHAR2(2000)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NCLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Data",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NVARCHAR2(2000)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NCLOB",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "BinaryData",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "RAW(2000)",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "BLOB",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Data",
+                schema: _schema.Schema,
+                table: "WorkflowInstances",
+                type: "NCLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NVARCHAR2(2000)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StringData",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NCLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NVARCHAR2(2000)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MaterializerContext",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NCLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NVARCHAR2(2000)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NCLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NVARCHAR2(2000)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Data",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "NCLOB",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "NVARCHAR2(2000)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "BinaryData",
+                schema: _schema.Schema,
+                table: "WorkflowDefinitions",
+                type: "BLOB",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "RAW(2000)",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/OracleProvidersExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/OracleProvidersExtensions.cs
@@ -65,7 +65,7 @@ public static class OracleProvidersExtensions
         feature.DbContextOptionsBuilder = (sp, db) => db.UseElsaOracle(migrationsAssembly, connectionStringFunc(sp), options, configure: configure);
         return (TFeature)feature;
     }
-
+    
     public static ElsaDbContextOptions Configure(this ElsaDbContextOptions options)
     {
         var management = new Management();

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Services/OracleWorkflowReferenceQuery.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Oracle/Services/OracleWorkflowReferenceQuery.cs
@@ -1,0 +1,44 @@
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Persistence.EFCore.Oracle.Services;
+
+/// <summary>
+/// Provides an implementation of <see cref="IWorkflowReferenceQuery"/> for querying Oracle databases
+/// to find all latest workflow definitions that reference a specific workflow definition.
+/// </summary>
+public class OracleWorkflowReferenceQuery(IDbContextFactory<ManagementElsaDbContext> dbContextFactory) : IWorkflowReferenceQuery
+{
+    public async Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var tableName = dbContext.Model.FindEntityType(typeof(WorkflowDefinition))!.GetSchemaQualifiedTableName();
+
+        var sql = $"""
+                       SELECT "DefinitionId", "TenantId"
+                       FROM {tableName}
+                       WHERE "IsLatest" = 1
+                         AND EXISTS (
+                           SELECT 1
+                           FROM JSON_TABLE(
+                             "StringData",
+                             '$.activities[*]'
+                             COLUMNS (
+                               workflowDefinitionId VARCHAR2(255) PATH '$.workflowDefinitionId',
+                               latestAvailablePublishedVersion VARCHAR2(4000) FORMAT JSON PATH '$.latestAvailablePublishedVersion'
+                             )
+                           ) act
+                           WHERE act.workflowDefinitionId = :p0
+                             AND act.latestAvailablePublishedVersion IS NOT NULL
+                         )
+                   """;
+
+
+        return await dbContext.Set<WorkflowDefinition>()
+            .FromSqlRaw(sql, workflowDefinitionId)
+            .Select(x => x.DefinitionId)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/DbContextFactories.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/DbContextFactories.cs
@@ -6,8 +6,10 @@ using Elsa.Persistence.EFCore.Modules.Labels;
 using Elsa.Persistence.EFCore.Modules.Management;
 using Elsa.Persistence.EFCore.Modules.Runtime;
 using Elsa.Persistence.EFCore.Modules.Tenants;
+using Elsa.Persistence.EFCore.PostgreSql.Handlers;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -33,6 +35,11 @@ public class TenantsDbContextFactories : PostgreSqlDesignTimeDbContextFactory<Te
 
 public class PostgreSqlDesignTimeDbContextFactory<TDbContext> : DesignTimeDbContextFactoryBase<TDbContext> where TDbContext : DbContext
 {
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IEntityModelCreatingHandler, SetupForPostgreSql>();
+    }
+    
     protected override void ConfigureBuilder(DbContextOptionsBuilder<TDbContext> builder, string connectionString)
     {
         builder.UseElsaPostgreSql(GetType().Assembly, connectionString);

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Extensions/DatabaseFacadeExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Extensions/DatabaseFacadeExtensions.cs
@@ -9,16 +9,6 @@ namespace Elsa.Persistence.EFCore.Extensions;
 public static class DatabaseFacadeExtensions
 {
     /// <summary>
-    /// Returns true if the database provider is MySql.
-    /// </summary>
-    public static bool IsMySql(this DatabaseFacade database) => database.ProviderName == "Pomelo.EntityFrameworkCore.MySql";
-    
-    /// <summary>
-    /// Returns true if the database provider is Oracle.
-    /// </summary>
-    public static bool IsOracle(this DatabaseFacade database) => database.ProviderName == "Oracle.EntityFrameworkCore";
-    
-    /// <summary>
     /// Returns true if the database provider is Postgres.
     /// </summary>
     public static bool IsPostgres(this DatabaseFacade database) => database.ProviderName == "Npgsql.EntityFrameworkCore.PostgreSQL";

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Handlers/SetupForPostgreSql.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Handlers/SetupForPostgreSql.cs
@@ -1,0 +1,28 @@
+using Elsa.Persistence.EFCore.Extensions;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Elsa.Persistence.EFCore.PostgreSql.Handlers;
+
+/// <summary>
+/// Represents a class that handles entity model creation for SQLite databases.
+/// </summary>
+public class SetupForPostgreSql : IEntityModelCreatingHandler
+{
+    /// <inheritdoc />
+    public void Handle(ElsaDbContextBase dbContext, ModelBuilder modelBuilder, IMutableEntityType entityType)
+    {
+        if (!dbContext.Database.IsPostgres())
+            return;
+
+        // Configure the WorkflowDefinition entity to use the PostgreSQL JSONB type for the StringData property:
+        if (entityType.ClrType == typeof(WorkflowDefinition))
+        {
+            modelBuilder
+                .Entity(entityType.Name)
+                .Property("StringData")
+                .HasColumnType("jsonb");
+        }
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Helpers/TableNameHelpers.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Helpers/TableNameHelpers.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Elsa.Persistence.EFCore.PostgreSql.Helpers;
+
+public static class TableNameHelpers
+{
+    public static string QuoteSchemaQualifiedTableName(this IEntityType entityType)
+    {
+        var schemaQualifiedTableName = entityType.GetSchemaQualifiedTableName()!;
+        return QuoteSchemaQualifiedTableName(schemaQualifiedTableName);
+    }
+    
+    public static string QuoteSchemaQualifiedTableName(string schemaQualifiedTableName)
+    {
+        var parts = schemaQualifiedTableName.Split('.');
+        return string.Join(".", parts.Select(p => $"\"{p}\""));
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Migrations/Management/20250711092046_V3_6.Designer.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Migrations/Management/20250711092046_V3_6.Designer.cs
@@ -3,86 +3,89 @@ using System;
 using Elsa.Persistence.EFCore.Modules.Management;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Oracle.EntityFrameworkCore.Metadata;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Elsa.Persistence.EFCore.Oracle.Migrations.Management
+namespace Elsa.Persistence.EFCore.PostgreSql.Migrations.Management
 {
     [DbContext(typeof(ManagementElsaDbContext))]
-    partial class ManagementElsaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250711092046_V3_6")]
+    partial class V3_6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
                 .HasAnnotation("ProductVersion", "9.0.6")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            OracleModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Elsa.Workflows.Management.Entities.WorkflowDefinition", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<byte[]>("BinaryData")
-                        .HasColumnType("RAW(2000)");
+                        .HasColumnType("bytea");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Description")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsLatest")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsReadonly")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsSystem")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("MaterializerContext")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("MaterializerName")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ProviderName")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("StringData")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("jsonb");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ToolVersion")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<bool?>("UsableAsActivity")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -117,62 +120,62 @@ namespace Elsa.Persistence.EFCore.Oracle.Migrations.Management
             modelBuilder.Entity("Elsa.Workflows.Management.Entities.WorkflowInstance", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("CorrelationId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DataCompressionAlgorithm")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefinitionVersionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("FinishedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("IncidentCount")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("IsExecuting")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsSystem")
-                        .HasColumnType("BOOLEAN");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ParentWorkflowInstanceId")
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("SubStatus")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("UpdatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Migrations/Management/20250711092046_V3_6.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Migrations/Management/20250711092046_V3_6.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Elsa.Persistence.EFCore.PostgreSql.Migrations.Management
+{
+    /// <inheritdoc />
+    public partial class V3_6 : Migration
+    {
+        private readonly Elsa.Persistence.EFCore.IElsaDbContextSchema _schema;
+
+        /// <inheritdoc />
+        public V3_6(Elsa.Persistence.EFCore.IElsaDbContextSchema schema)
+        {
+            _schema = schema;
+        }
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var schema = _schema.Schema;
+            migrationBuilder.Sql($@"
+                ALTER TABLE ""{schema}"".""WorkflowDefinitions""
+                ALTER COLUMN ""StringData""
+                TYPE jsonb
+                USING ""StringData""::jsonb;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            var schema = _schema.Schema;
+            migrationBuilder.Sql($@"
+                ALTER TABLE ""{schema}"".""WorkflowDefinitions""
+                ALTER COLUMN ""StringData""
+                TYPE text
+                USING ""StringData""::text;
+            ");
+        }
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Migrations/Management/ManagementElsaDbContextModelSnapshot.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Migrations/Management/ManagementElsaDbContextModelSnapshot.cs
@@ -18,7 +18,7 @@ namespace Elsa.Persistence.EFCore.PostgreSql.Migrations.Management
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
-                .HasAnnotation("ProductVersion", "8.0.12")
+                .HasAnnotation("ProductVersion", "9.0.6")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -70,7 +70,7 @@ namespace Elsa.Persistence.EFCore.PostgreSql.Migrations.Management
                         .HasColumnType("text");
 
                     b.Property<string>("StringData")
-                        .HasColumnType("text");
+                        .HasColumnType("jsonb");
 
                     b.Property<string>("TenantId")
                         .HasColumnType("text");

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/PostgreSqlProvidersExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/PostgreSqlProvidersExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Reflection;
+using Elsa.Extensions;
+using Elsa.Persistence.EFCore.PostgreSql.Handlers;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 
 // ReSharper disable once CheckNamespace
@@ -50,6 +52,7 @@ public static class PostgreSqlProvidersExtensions
         where TDbContext : ElsaDbContextBase
         where TFeature : PersistenceFeatureBase<TFeature, TDbContext>
     {
+        feature.Module.Services.TryAddScopedImplementation<IEntityModelCreatingHandler, SetupForPostgreSql>();
         feature.DbContextOptionsBuilder = (sp, db) => db.UseElsaPostgreSql(migrationsAssembly, connectionStringFunc(sp), options, configure: configure);
         return (TFeature)feature;
     }

--- a/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Services/PostgreSqlWorkflowReferenceQuery.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.PostgreSql/Services/PostgreSqlWorkflowReferenceQuery.cs
@@ -1,0 +1,45 @@
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Persistence.EFCore.PostgreSql.Helpers;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Persistence.EFCore.PostgreSql.Services;
+
+/// <summary>
+/// Provides an implementation of <see cref="IWorkflowReferenceQuery"/> for querying PostgreSQL databases
+/// to find all latest workflow definitions that reference a specific workflow definition.
+/// </summary>
+public class PostgreSqlWorkflowReferenceQuery(IDbContextFactory<ManagementElsaDbContext> dbContextFactory) : IWorkflowReferenceQuery
+{
+    public async Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var tableName = dbContext.Model.FindEntityType(typeof(WorkflowDefinition))!.QuoteSchemaQualifiedTableName();
+
+        var sql = $"""
+                       SELECT `DefinitionId`, `TenantId`
+                       FROM {tableName}
+                       WHERE `IsLatest` = 1
+                         AND EXISTS (
+                           SELECT 1
+                           FROM JSON_TABLE(
+                             `StringData`,
+                             '$.activities[*]'
+                             COLUMNS (
+                               workflowDefinitionId VARCHAR(255) PATH '$.workflowDefinitionId',
+                               latestAvailablePublishedVersion JSON PATH '$.latestAvailablePublishedVersion'
+                             )
+                           ) AS act
+                           WHERE act.workflowDefinitionId = @p0
+                             AND act.latestAvailablePublishedVersion IS NOT NULL
+                         );
+                   """;
+
+
+        return await dbContext.Set<WorkflowDefinition>()
+            .FromSqlRaw(sql, workflowDefinitionId)
+            .Select(x => x.DefinitionId)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.SqlServer/Services/SqlServerWorkflowReferenceQuery.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.SqlServer/Services/SqlServerWorkflowReferenceQuery.cs
@@ -1,0 +1,31 @@
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Persistence.EFCore.SqlServer.Services;
+
+/// <summary>
+/// Provides an implementation of <see cref="IWorkflowReferenceQuery"/> for querying SQL Server databases
+/// to find all latest workflow definitions that reference a specific workflow definition.
+/// </summary>
+public class SqlServerWorkflowReferenceQuery(IDbContextFactory<ManagementElsaDbContext> dbContextFactory) : IWorkflowReferenceQuery
+{
+    public async Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var tableName = dbContext.Model.FindEntityType(typeof(WorkflowDefinition))!.GetSchemaQualifiedTableName();
+        
+        var sql = $"""
+                  SELECT [DefinitionId], [TenantId] FROM {tableName} WHERE [IsLatest] = 1 AND EXISTS (
+                  SELECT 1 FROM OPENJSON(JSON_QUERY([StringData], '$.activities')) AS value
+                  WHERE JSON_VALUE(value, '$.workflowDefinitionId') = @p0
+                  AND JSON_VALUE(value, '$.latestAvailablePublishedVersion') IS NOT NULL)
+                  """;
+        
+        return await dbContext.Set<WorkflowDefinition>()
+            .FromSqlRaw(sql, workflowDefinitionId)
+            .Select(x => x.DefinitionId)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Sqlite/Services/SqliteWorkflowReferenceQuery.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Sqlite/Services/SqliteWorkflowReferenceQuery.cs
@@ -1,0 +1,31 @@
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Persistence.EFCore.Sqlite.Services;
+
+/// <summary>
+/// Provides an implementation of <see cref="IWorkflowReferenceQuery"/> for querying SQLite databases
+/// to find all latest workflow definitions that reference a specific workflow definition.
+/// </summary>
+public class SqliteWorkflowReferenceQuery(IDbContextFactory<ManagementElsaDbContext> dbContextFactory) : IWorkflowReferenceQuery
+{
+    public async Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var tableName = dbContext.Model.FindEntityType(typeof(WorkflowDefinition))!.GetTableName();
+        
+        var sql = $"""
+                    SELECT DefinitionId, TenantId FROM {tableName} WHERE IsLatest = 1 AND EXISTS (
+                    SELECT 1 FROM json_each(json_extract(StringData, '$.activities'))
+                    WHERE json_extract(value, '$.workflowDefinitionId') = @p0
+                    AND json_extract(value, '$.latestAvailablePublishedVersion') IS NOT NULL)
+                   """;
+        
+        return await dbContext.Set<WorkflowDefinition>()
+            .FromSqlRaw(sql, workflowDefinitionId)
+            .Select(x => x.DefinitionId)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/modules/persistence/Elsa.Persistence.EFCore.Sqlite/SqliteProvidersExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.EFCore.Sqlite/SqliteProvidersExtensions.cs
@@ -68,7 +68,6 @@ public static class SqliteProvidersExtensions
         where TDbContext : ElsaDbContextBase
         where TFeature : PersistenceFeatureBase<TFeature, TDbContext>
     {
-        
         feature.Module.Services.TryAddScopedImplementation<IEntityModelCreatingHandler, SetupForSqlite>();
         feature.DbContextOptionsBuilder = (sp, db) => db.UseElsaSqlite(migrationsAssembly, connectionStringFunc(sp), options, configure: configure);
         return (TFeature)feature;

--- a/src/modules/persistence/Elsa.Persistence.EFCore/efcore-3.6.sh
+++ b/src/modules/persistence/Elsa.Persistence.EFCore/efcore-3.6.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Define the modules to update
+mods=("Management")
+
+# Define the list of providers
+# providers=("MySql" "SqlServer" "Sqlite" "PostgreSql" "Oracle")
+providers=("Oracle")
+
+# Loop through each module
+for module in "${mods[@]}"; do
+    # Loop through each provider
+    for provider in "${providers[@]}"; do
+        providerPath="../Elsa.Persistence.EFCore.$provider"
+        startupProject="$providerPath/Elsa.Persistence.EFCore.$provider.csproj"
+        migrationsPath="Migrations/$module"
+    
+        echo "Updating migrations for $provider..."
+        echo "Provider path: ${providerPath:?}"
+        echo "Startup project: $startupProject"
+        echo "Migrations path: $migrationsPath"
+        ef-migration-runtime-schema --interface Elsa.Persistence.EFCore.IElsaDbContextSchema --efOptions "migrations add V3_6 -c ""$module""ElsaDbContext -p ""$providerPath""  -o ""$migrationsPath"" --startup-project ""$startupProject"""
+    done
+done


### PR DESCRIPTION
Remove `DatabaseFacadeExtensions` and introduce `IWorkflowReferenceQuery` with its default implementation. Implement database schema updates for PostgreSQL, MySQL, and Oracle to enhance compatibility with the V3.6 data structure.
