### PR TITLE
BREAKING: Enhance Sql Evaluator to Support Object Properties

### DIFF
--- a/src/modules/sql/Elsa.Sql/Services/SqlEvaluator.cs
+++ b/src/modules/sql/Elsa.Sql/Services/SqlEvaluator.cs
@@ -118,7 +118,7 @@ public class SqlEvaluator() : ISqlEvaluator
 
         // TODO: Remove deprecated keys in a future major release and re-order these.
         // Handle custom keys
-        return key switch
+        var switchResult = key switch
         {
             "Workflow.Definition.Id" => executionContext.Workflow.Identity.DefinitionId,    // Deprecated, use {{Workflow.Identity.DefinitionId}} instead.
             "Workflow.Definition.Version.Id" => executionContext.Workflow.Identity.Id,      // Deprecated, use {{Workflow.Identity.Id}} instead.
@@ -126,8 +126,10 @@ public class SqlEvaluator() : ISqlEvaluator
             "Workflow.Instance.Id" => activityContext.WorkflowExecutionContext.Id,          // Deprecated, use {{Activity.WorkflowExecutionContext.Id}} instead.
             "Correlation.Id" => activityContext.WorkflowExecutionContext.CorrelationId,     // Deprecated, use {{Activity.WorkflowExecutionContext.CorrelationId}} instead.
             "LastResult" => expressionContext.GetLastResult(),
-            //_ => throw new NullReferenceException($"No matching property found for {{{{{key}}}}}.")
+            _ => null //throw new NullReferenceException($"No matching property found for {{{{{key}}}}}.")
         };
+        if (switchResult is not null)
+            return switchResult;
 
         if (key.StartsWith("Workflow."))
         {

--- a/src/modules/sql/README.md
+++ b/src/modules/sql/README.md
@@ -39,6 +39,7 @@ This package extends [Elsa Workflows](https://github.com/elsa-workflows/elsa-cor
 - Automatic sql parameterization of Variables, Inputs, Outputs and other keywords to help Sql injection.
 - Add-in approach to each database provider, with the ability to easily integrate other providers using the `ISqlClient` interface.
 - Syntax highlighting for SQL
+- `NEW` (3.6.0)  - Support for resolving JSON, POCO's, Objects and ExpandoObjects. 
 
 ---
 
@@ -163,15 +164,52 @@ SELECT * FROM [Users] WHERE [Name] = @p1 AND [Age] > @p2;
 
 ### Supported Expressions
 
-```csharp
-{{Workflow.Definition.Id}}
-{{Workflow.Definition.Version}}
-{{Workflow.Instance.Id}} 
-{{Correlation.Id}}
+```liquid
 {{LastResult}} 
 {{Input.<InputName>}}
 {{Output.<OutputName>}}
 {{Variable.<VariableName>}}
+{{Variables.<VariableName>}}
+{{Workflow.Definition.Id}}
+{{Workflow.Definition.Version.Id}}
+{{Workflow.Definition.Version}}
+{{Workflow.Instance.Id}}
+{{Correlation.Id}}
+```
+
+### Enhanced expressions (3.6.0 and later)
+Expressions can now also resolve nested properties in:
+- POCOs
+- ExpandoObject
+- IDictionary
+- Arrays
+- Lists
+- JSON objects
+
+There is also added support for accessing properties in:
+- `ActivityContext`, aliased as `Activity`
+- `ExecutionContext`, aliased as `Execution`
+- `ExecutionContext.Workflow`, aliased as `Workflow`
+
+To access these properties, you can use the following syntax:
+
+```liquid
+{{Variable.MyObject.User.Id}}
+{{Variable.MyObject.Users[3].Name}}
+{{Activity.MyObject.Users[2].Age}}
+{{Workflow.Identity.DefinitionId}}
+{{Activity.WorkflowExecutionContext.Id}}
+```
+
+With these new improvements the following expression keys will be deprecated and removed in a future release.
+To continue using these properties, please update your expressions as follows:
+```liquid
+{{Variables.<VariableName>}}        -->     {{Variable.<VariableName>}}
+{{Workflow.Definition.Id}}          -->     {{Workflow.Identity.DefinitionId}}
+{{Workflow.Definition.Version.Id}}  -->     {{Workflow.Identity.Id}}
+{{Workflow.Definition.Version}}     -->     {{Workflow.Identity.Version}}
+{{Workflow.Instance.Id}}            -->     {{Activity.WorkflowExecutionContext.Id}}
+{{Correlation.Id}}                  -->     {{Activity.WorkflowExecutionContext.CorrelationId}}
 ```
 
 ---

--- a/src/modules/sql/README.md
+++ b/src/modules/sql/README.md
@@ -162,23 +162,17 @@ SELECT * FROM [Users] WHERE [Name] = @p1 AND [Age] > @p2;
 ```
 
 
-### Supported Expressions
+### Expressions
+
+You can use Liquid-like expressions to access Input, Output and Variable values in your query.
 
 ```liquid
-{{LastResult}} 
 {{Input.<InputName>}}
 {{Output.<OutputName>}}
 {{Variable.<VariableName>}}
-{{Variables.<VariableName>}}
-{{Workflow.Definition.Id}}
-{{Workflow.Definition.Version.Id}}
-{{Workflow.Definition.Version}}
-{{Workflow.Instance.Id}}
-{{Correlation.Id}}
 ```
 
-### Enhanced expressions (3.6.0 and later)
-Expressions can now also resolve nested properties in:
+Expressions can also access objects with nested properties. The following objects are supported:
 - POCOs
 - ExpandoObject
 - IDictionary
@@ -186,23 +180,29 @@ Expressions can now also resolve nested properties in:
 - Lists
 - JSON objects
 
-There is also added support for accessing properties in:
+```liquid
+{{Input.MyObjectArr[0]}}
+{{Variable.MyObject.User.Id}}
+{{Variable.MyObject.Users[3].Name}}
+{{Activity.MyObject.Users[2].Age}}
+```
+
+There is also added support for accessing workflow related properties:
 - `ActivityContext`, aliased as `Activity`
 - `ExecutionContext`, aliased as `Execution`
 - `ExecutionContext.Workflow`, aliased as `Workflow`
 
-To access these properties, you can use the following syntax:
-
 ```liquid
-{{Variable.MyObject.User.Id}}
-{{Variable.MyObject.Users[3].Name}}
-{{Activity.MyObject.Users[2].Age}}
+{{LastResult}} 
 {{Workflow.Identity.DefinitionId}}
 {{Activity.WorkflowExecutionContext.Id}}
 ```
 
-With these new improvements the following expression keys will be deprecated and removed in a future release.
-To continue using these properties, please update your expressions as follows:
+### Breaking Expression Changes in 3.6.0
+
+As the evaluator can now use workflow properties directly, the previous hard coded expression keys have been be removed.
+To access the previous key values you will need to update your expressions.
+
 ```liquid
 {{Variables.<VariableName>}}        -->     {{Variable.<VariableName>}}
 {{Workflow.Definition.Id}}          -->     {{Workflow.Identity.DefinitionId}}


### PR DESCRIPTION
Closes #85 

- Added support for resolving nested properties and arrays in expressions, including POCOs, ExpandoObject, IDictionary, arrays, lists, and JSON objects.
- Introduced new context prefixes (`Activity.`, `Execution.`, `Workflow.`) for accessing specific contexts and their nested properties.
- Marks older prefixes (`Variables.`) and certain keys (`Workflow.Definition.Id`, etc.) as deprecated. Providing updated alternatives.
- Improved error handling for missing properties, invalid indices, and unsupported types.
- Updated README to document new features, provide examples of enhanced expression syntax, and guide migration from deprecated keys.


# Breaking Expression Changes

As the evaluator can now use workflow properties directly, the previous hard coded expression keys have been be removed.
To access the previous key values you will need to update your expressions.

```liquid
{{Variables.<VariableName>}}        -->     {{Variable.<VariableName>}}
{{Workflow.Definition.Id}}          -->     {{Workflow.Identity.DefinitionId}}
{{Workflow.Definition.Version.Id}}  -->     {{Workflow.Identity.Id}}
{{Workflow.Definition.Version}}     -->     {{Workflow.Identity.Version}}
{{Workflow.Instance.Id}}            -->     {{Activity.WorkflowExecutionContext.Id}}
{{Correlation.Id}}                  -->     {{Activity.WorkflowExecutionContext.CorrelationId}}
```