### PR TITLE
Fix AggregateFaultCount int column using system method NewGuid

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.Dapper.Migrations/Runtime/V3_5.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper.Migrations/Runtime/V3_5.cs
@@ -14,7 +14,7 @@ public class V3_5 : Migration
     /// <inheritdoc />
     public override void Up()
     {
-        Alter.Table("ActivityExecutionRecords").AddColumn("AggregateFaultCount").AsInt32().NotNullable().WithDefault(0);
+        Alter.Table("ActivityExecutionRecords").AddColumn("AggregateFaultCount").AsInt32().NotNullable().WithDefaultValue(0);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
# Problem

In Elsa.Dapper.Migrations, more precisely in the `V3_5` migration, an incorrect default of `NewGuid` is applied to an Int32 column.
This is due to calling `.WithDefault(0)`, which is a method accepting `SystemMethods`.
`SystemMethods` is an enum having `NewGuid` with ordinal `0`, and therefore the value `0` is implicitly casted to `SystemMethods.NewGuid`, while the intention was to set the primitive value `0` as the default for the `AggregateFaultCount` column in the `ActivityExecutionRecords` table.

See #96 for more details.

# Solution

The solution is to simply call `WithDefaultValue(0)` instead.
This method accepts primitive values.