### PR TITLE
Add defensive check to `GetRecurringJobIds` to prevent null reference exception

### DIFF
--- a/src/modules/scheduling/Elsa.Scheduling.Hangfire/Services/HangfireWorkflowScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Hangfire/Services/HangfireWorkflowScheduler.cs
@@ -97,7 +97,9 @@ public class HangfireWorkflowScheduler(
     private IEnumerable<string> GetRecurringJobIds<TJob>(string taskName)
     {
         using var connection = jobStorage.GetConnection();
-        var jobs = connection.GetRecurringJobs().Where(x => x.Job.Type == typeof(TJob) && (string)x.Job.Args[0] == taskName);
+        var jobs = connection.GetRecurringJobs()
+            .Where(x => x.Job is { Args.Count: > 0 } && x.Job.Type == typeof(TJob) && (string)x.Job.Args[0] == taskName);
+        
         return jobs.Select(x => x.Id).Distinct().ToList();
     }
 }


### PR DESCRIPTION
In the `HangfireWorkflowScheduler`, it is possible for the `GetRecurringJobIds` method to throw a null reference exception, and I have observed this occurring when multiple instances have their triggers being updated after a workflow definition change at the same time, even with distributed locking set up in Elsa. I believe this will at least prevent the null reference exception; without this, the handler crashes and recurring jobs get left around.

Below is a snippet from the Hangfire code that retrieves the list

https://github.com/HangfireIO/Hangfire/blob/eb994c324c0ed2687e2c35412c72460a1c1f9e71/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs#L75

```
        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection)
        {
            if (connection == null) throw new ArgumentNullException(nameof(connection));

            var ids = connection.GetAllItemsFromSet("recurring-jobs");
            return GetRecurringJobDtos(connection, ids);
        }
```

And the `GetRecurringJobDtos` method can definitely return objects without a `Job` set.

https://github.com/HangfireIO/Hangfire/blob/eb994c324c0ed2687e2c35412c72460a1c1f9e71/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs#L89

```
        private static List<RecurringJobDto> GetRecurringJobDtos(IStorageConnection connection, IEnumerable<string> ids)
        {
            var result = new List<RecurringJobDto>();
            foreach (var id in ids)
            {
                var hash = connection.GetAllEntriesFromHash($"recurring-job:{id}");

                // TODO: Remove this in 2.0 (breaking change)
                if (hash == null)
                {
                    result.Add(new RecurringJobDto { Id = id, Removed = true });
                    continue;
                }

                var dto = new RecurringJobDto { Id = id };

                if (hash.TryGetValue("Cron", out var cron) && !String.IsNullOrWhiteSpace(cron))
                {
                    dto.Cron = cron;
                }

                try
                {
                    if (hash.TryGetValue("Job", out var payload) && !String.IsNullOrWhiteSpace(payload))
                    {
                        var invocationData = InvocationData.DeserializePayload(payload);
                        dto.Job = invocationData.DeserializeJob();
                    }
                }
                catch (JobLoadException ex)
                {
                    dto.LoadException = ex;
                }
```
