### PR TITLE
feature: Add option to configure custom azure servicebus processor options

### DIFF
--- a/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -37,6 +37,11 @@ public class AzureServiceBusFeature : FeatureBase
     public Action<AzureServiceBusOptions> AzureServiceBusOptions { get; set; } = _ => { };
 
     /// <summary>
+    /// A delegate to create a <see cref="AzureServiceBusOptions"/> instance.
+    /// </summary>
+    public Func<IServiceProvider, ServiceBusProcessorOptions> ProcessorOptionsFactory { get; set; } = _ => new ServiceBusProcessorOptions();
+
+    /// <summary>
     /// A delegate to create a <see cref="ServiceBusAdministrationClient"/> instance.
     /// </summary>
     public Func<IServiceProvider, ServiceBusClient> ServiceBusClientFactory { get; set; } = sp => new(GetConnectionString(sp));
@@ -68,6 +73,7 @@ public class AzureServiceBusFeature : FeatureBase
         Services
             .AddSingleton(ServiceBusAdministrationClientFactory)
             .AddSingleton(ServiceBusClientFactory)
+            .AddSingleton(ProcessorOptionsFactory)
             .AddSingleton<ConfigurationQueueTopicAndSubscriptionProvider>()
             .AddSingleton<IWorkerManager, WorkerManager>()
             .AddScoped<IServiceBusInitializer, ServiceBusInitializer>();

--- a/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/Options/AzureServiceBusOptions.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/Options/AzureServiceBusOptions.cs
@@ -1,3 +1,4 @@
+using Azure.Messaging.ServiceBus;
 using Elsa.ServiceBus.AzureServiceBus.Models;
 
 namespace Elsa.ServiceBus.AzureServiceBus.Options;

--- a/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/Services/Worker.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/Services/Worker.cs
@@ -20,15 +20,14 @@ public class Worker : IAsyncDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="Worker"/> class.
     /// </summary>
-    public Worker(string queueOrTopic, string? subscription, ServiceBusClient client, IServiceScopeFactory serviceScopeFactory, ILogger<Worker> logger)
+    public Worker(string queueOrTopic, string? subscription, ServiceBusClient client, ServiceBusProcessorOptions processorOptions, IServiceScopeFactory serviceScopeFactory, ILogger<Worker> logger)
     {
         QueueOrTopic = queueOrTopic;
         Subscription = subscription == "" ? null : subscription;
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
 
-        var options = new ServiceBusProcessorOptions();
-        var processor = string.IsNullOrEmpty(subscription) ? client.CreateProcessor(queueOrTopic, options) : client.CreateProcessor(queueOrTopic, subscription, options);
+        var processor = string.IsNullOrEmpty(subscription) ? client.CreateProcessor(queueOrTopic, processorOptions) : client.CreateProcessor(queueOrTopic, subscription, processorOptions);
 
         processor.ProcessMessageAsync += OnMessageReceivedAsync;
         processor.ProcessErrorAsync += OnErrorAsync;


### PR DESCRIPTION
This allows the user to configure the processor for concurrent calls, prefetching, to not autocomplete messages (but manually in the workflow for example) or reduce or increase the timeouts.