### PR TITLE
[codex] Order Quartz lifecycle initializers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -141,13 +141,13 @@
         <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.12.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
         <PackageVersion Include="Cronos" Version="0.11.1"/>
-        <PackageVersion Include="CShells" Version="0.0.18"/>
-        <PackageVersion Include="CShells.Abstractions" Version="0.0.18"/>
-        <PackageVersion Include="CShells.AspNetCore" Version="0.0.18"/>
-        <PackageVersion Include="CShells.AspNetCore.Abstractions" Version="0.0.18"/>
-        <PackageVersion Include="CShells.FastEndpoints" Version="0.0.18"/>
-        <PackageVersion Include="CShells.FastEndpoints.Abstractions" Version="0.0.18"/>
-        <PackageVersion Include="CShells.Providers.FluentStorage" Version="0.0.18"/>
+        <PackageVersion Include="CShells" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells.Abstractions" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells.AspNetCore" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells.AspNetCore.Abstractions" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells.FastEndpoints" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells.FastEndpoints.Abstractions" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells.Providers.FluentStorage" Version="0.0.21-preview.120"/>
         <PackageVersion Include="CsvHelper" Version="33.1.0"/>
         <PackageVersion Include="Dapper" Version="2.1.66"/>
         <PackageVersion Include="DistributedLock" Version="2.7.1"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -141,13 +141,13 @@
         <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.12.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
         <PackageVersion Include="Cronos" Version="0.11.1"/>
-        <PackageVersion Include="CShells" Version="0.0.21-preview.120"/>
-        <PackageVersion Include="CShells.Abstractions" Version="0.0.21-preview.120"/>
-        <PackageVersion Include="CShells.AspNetCore" Version="0.0.21-preview.120"/>
-        <PackageVersion Include="CShells.AspNetCore.Abstractions" Version="0.0.21-preview.120"/>
-        <PackageVersion Include="CShells.FastEndpoints" Version="0.0.21-preview.120"/>
-        <PackageVersion Include="CShells.FastEndpoints.Abstractions" Version="0.0.21-preview.120"/>
-        <PackageVersion Include="CShells.Providers.FluentStorage" Version="0.0.21-preview.120"/>
+        <PackageVersion Include="CShells" Version="0.0.21"/>
+        <PackageVersion Include="CShells.Abstractions" Version="0.0.21"/>
+        <PackageVersion Include="CShells.AspNetCore" Version="0.0.21"/>
+        <PackageVersion Include="CShells.AspNetCore.Abstractions" Version="0.0.21"/>
+        <PackageVersion Include="CShells.FastEndpoints" Version="0.0.21"/>
+        <PackageVersion Include="CShells.FastEndpoints.Abstractions" Version="0.0.21"/>
+        <PackageVersion Include="CShells.Providers.FluentStorage" Version="0.0.21"/>
         <PackageVersion Include="CsvHelper" Version="33.1.0"/>
         <PackageVersion Include="Dapper" Version="2.1.66"/>
         <PackageVersion Include="DistributedLock" Version="2.7.1"/>

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/ShellFeatures/QuartzMySqlFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/ShellFeatures/QuartzMySqlFeature.cs
@@ -35,8 +35,7 @@ public class QuartzMySqlFeature : IShellFeature
         else
             services.AddDbContextFactory<MySqlQuartzDbContext>(Configure);
 
-        services.AddTransient<IShellInitializer>(sp =>
-            new EfCoreMigrationHandler(sp.GetRequiredService<IDbContextFactory<MySqlQuartzDbContext>>()));
+        services.AddShellInitializer<EfCoreMigrationHandler>(LifecyclePhase.Prepare, order: 100);
 
         services.AddQuartz(quartz =>
         {

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/ShellFeatures/QuartzPostgreSqlFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/ShellFeatures/QuartzPostgreSqlFeature.cs
@@ -35,8 +35,7 @@ public class QuartzPostgreSqlFeature : IShellFeature
         else
             services.AddDbContextFactory<PostgreSqlQuartzDbContext>(Configure);
 
-        services.AddTransient<IShellInitializer>(sp =>
-            new EfCoreMigrationHandler(sp.GetRequiredService<IDbContextFactory<PostgreSqlQuartzDbContext>>()));
+        services.AddShellInitializer<EfCoreMigrationHandler>(LifecyclePhase.Prepare, order: 100);
 
         services.AddQuartz(quartz =>
         {

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/ShellFeatures/QuartzSqlServerFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/ShellFeatures/QuartzSqlServerFeature.cs
@@ -35,8 +35,7 @@ public class QuartzSqlServerFeature : IShellFeature
         else
             services.AddDbContextFactory<SqlServerQuartzDbContext>(Configure);
 
-        services.AddTransient<IShellInitializer>(sp =>
-            new EfCoreMigrationHandler(sp.GetRequiredService<IDbContextFactory<SqlServerQuartzDbContext>>()));
+        services.AddShellInitializer<EfCoreMigrationHandler>(LifecyclePhase.Prepare, order: 100);
 
         // AddQuartz is additive — layers the persistent store onto the base
         // AddQuartz call already made by QuartzFeature (which ran first via DependsOn).

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/ShellFeatures/QuartzSqliteFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/ShellFeatures/QuartzSqliteFeature.cs
@@ -38,9 +38,7 @@ public class QuartzSqliteFeature : IShellFeature, IPostConfigureShellServices
         else
             services.AddDbContextFactory<SqliteQuartzDbContext>(Configure);
 
-        services.AddTransient<IShellInitializer>(sp =>
-            new EfCoreMigrationHandler(
-                sp.GetRequiredService<IDbContextFactory<SqliteQuartzDbContext>>()));
+        services.AddShellInitializer<EfCoreMigrationHandler>(LifecyclePhase.Prepare, order: 100);
     }
 
     public void PostConfigureServices(IServiceCollection services)

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzShellLifecycleHandler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzShellLifecycleHandler.cs
@@ -15,6 +15,7 @@ namespace Elsa.Scheduling.Quartz.ShellFeatures;
 /// so the <c>AwaitApplicationStarted</c> deferral logic from <c>QuartzHostedService</c>
 /// is intentionally omitted — it is irrelevant in this context.
 /// </remarks>
+[LifecycleOrder(LifecyclePhase.Start, 100)]
 public class QuartzShellLifecycleHandler(
     IQuartzSchedulerFactory schedulerFactory,
     IHostApplicationLifetime appLifetime,

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Elsa.Scheduling.Quartz.UnitTests.csproj
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Elsa.Scheduling.Quartz.UnitTests.csproj
@@ -2,6 +2,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\..\src\modules\scheduling\Elsa.Scheduling.Quartz\Elsa.Scheduling.Quartz.csproj" />
+      <ProjectReference Include="..\..\..\..\src\modules\scheduling\Elsa.Scheduling.Quartz.EFCore.MySql\Elsa.Scheduling.Quartz.EFCore.MySql.csproj" />
+      <ProjectReference Include="..\..\..\..\src\modules\scheduling\Elsa.Scheduling.Quartz.EFCore.PostgreSql\Elsa.Scheduling.Quartz.EFCore.PostgreSql.csproj" />
+      <ProjectReference Include="..\..\..\..\src\modules\scheduling\Elsa.Scheduling.Quartz.EFCore.SqlServer\Elsa.Scheduling.Quartz.EFCore.SqlServer.csproj" />
+      <ProjectReference Include="..\..\..\..\src\modules\scheduling\Elsa.Scheduling.Quartz.EFCore.Sqlite\Elsa.Scheduling.Quartz.EFCore.Sqlite.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/ShellFeatures/QuartzFeatureTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/ShellFeatures/QuartzFeatureTests.cs
@@ -2,6 +2,7 @@ using CShells.Features;
 using CShells.Lifecycle;
 using Elsa.Scheduling.Quartz.ShellFeatures;
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
 
 namespace Elsa.Scheduling.Quartz.UnitTests.ShellFeatures;
 
@@ -24,6 +25,16 @@ public class QuartzFeatureTests
         Assert.Equal(2, initializerRegistrations.Count);
         Assert.Equal(typeof(DependentInitializer), initializerRegistrations[0].ImplementationType);
         Assert.NotNull(initializerRegistrations[1].ImplementationFactory);
+    }
+
+    [Fact]
+    public void SchedulerInitializer_RunsInStartPhase()
+    {
+        var order = typeof(QuartzShellLifecycleHandler).GetCustomAttribute<LifecycleOrderAttribute>();
+
+        Assert.NotNull(order);
+        Assert.Equal(LifecyclePhase.Start, order.Phase);
+        Assert.Equal(100, order.Order);
     }
 
     private sealed class DependentInitializer : IShellInitializer

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/ShellFeatures/QuartzFeatureTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/ShellFeatures/QuartzFeatureTests.cs
@@ -1,5 +1,9 @@
 using CShells.Features;
 using CShells.Lifecycle;
+using Elsa.Scheduling.Quartz.EFCore.MySql.ShellFeatures;
+using Elsa.Scheduling.Quartz.EFCore.PostgreSql.ShellFeatures;
+using Elsa.Scheduling.Quartz.EFCore.SqlServer.ShellFeatures;
+using Elsa.Scheduling.Quartz.EFCore.Sqlite.ShellFeatures;
 using Elsa.Scheduling.Quartz.ShellFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
@@ -36,6 +40,32 @@ public class QuartzFeatureTests
         Assert.Equal(LifecyclePhase.Start, order.Phase);
         Assert.Equal(100, order.Order);
     }
+
+    [Theory]
+    [MemberData(nameof(QuartzStoreFeatures))]
+    public void StoreMigrationInitializer_RunsInPreparePhase(IShellFeature feature)
+    {
+        var services = new ServiceCollection();
+
+        feature.ConfigureServices(services);
+
+        var initializer = Assert.Single(services, x => x.ServiceType == typeof(IShellInitializer));
+        var registrationDescriptor = Assert.Single(services, x => x.ServiceType == typeof(ShellInitializerRegistration));
+        var registration = Assert.IsType<ShellInitializerRegistration>(registrationDescriptor.ImplementationInstance);
+
+        Assert.NotNull(initializer.ImplementationFactory);
+        Assert.Equal(LifecyclePhase.Prepare, registration.Phase);
+        Assert.Equal(100, registration.Order);
+        Assert.True(typeof(IShellInitializer).IsAssignableFrom(registration.InitializerType));
+    }
+
+    public static TheoryData<IShellFeature> QuartzStoreFeatures() => new()
+    {
+        new QuartzMySqlFeature(),
+        new QuartzPostgreSqlFeature(),
+        new QuartzSqlServerFeature(),
+        new QuartzSqliteFeature()
+    };
 
     private sealed class DependentInitializer : IShellInitializer
     {


### PR DESCRIPTION
## Summary
- update CShells package references to the lifecycle-ordering stable release
- run Quartz EF Core migrations in the Prepare lifecycle phase
- run Quartz scheduler startup in the Start lifecycle phase
- add a unit test for the Quartz scheduler lifecycle metadata

## Why
Quartz scheduler startup could run before the provider-specific EF Core migration initializer, because feature dependencies still sort provider features after the base Quartz feature. CShells now separates feature dependency ordering from lifecycle initializer ordering, so providers can prepare storage before the runtime starts.

## Validation
- `dotnet restore test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Elsa.Scheduling.Quartz.UnitTests.csproj --configfile /Users/sipke/.nuget/NuGet/NuGet.Config && dotnet test test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Elsa.Scheduling.Quartz.UnitTests.csproj --no-restore`
- `dotnet restore src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/Elsa.Scheduling.Quartz.EFCore.PostgreSql.csproj --configfile /Users/sipke/.nuget/NuGet/NuGet.Config && dotnet build src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/Elsa.Scheduling.Quartz.EFCore.PostgreSql.csproj --no-restore`
- `dotnet restore src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/Elsa.Scheduling.Quartz.EFCore.SqlServer.csproj --configfile /Users/sipke/.nuget/NuGet/NuGet.Config && dotnet build src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/Elsa.Scheduling.Quartz.EFCore.SqlServer.csproj --no-restore`
- `dotnet restore src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/Elsa.Scheduling.Quartz.EFCore.Sqlite.csproj --configfile /Users/sipke/.nuget/NuGet/NuGet.Config && dotnet build src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/Elsa.Scheduling.Quartz.EFCore.Sqlite.csproj --no-restore`
- `dotnet restore src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/Elsa.Scheduling.Quartz.EFCore.MySql.csproj --configfile /Users/sipke/.nuget/NuGet/NuGet.Config && dotnet build src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/Elsa.Scheduling.Quartz.EFCore.MySql.csproj --no-restore`

Warnings observed are pre-existing: NU1903 for Snappier and an obsolete WorkflowGraphNotFoundException usage.