### PR TITLE
Add platform runtime kind hints to generator-backed modules

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
         <PackageVersion Include="Elsa.Workflows.Management" Version="$(ElsaVersion)"/>
         <PackageVersion Include="Elsa.Workflows.Runtime" Version="$(ElsaVersion)"/>
         <PackageVersion Include="Elsa.Workflows.Runtime.Distributed" Version="$(ElsaVersion)"/>
-        <PackageVersion Include="Elsa.PackageManifest.Generator" Version="0.0.1-preview.43"/>
+        <PackageVersion Include="Elsa.Platform.PackageManifest.Generator" Version="0.0.1-preview.50"/>
         <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0-preview.260212.1"/>
     </ItemGroup>
     <ItemGroup Label="Elsa Studio">

--- a/src/modules/Directory.Build.props
+++ b/src/modules/Directory.Build.props
@@ -18,7 +18,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/ShellFeatures')">
-    <PackageReference Include="Elsa.PackageManifest.Generator" PrivateAssets="all" />
+    <PackageReference Include="Elsa.Platform.PackageManifest.Generator" PrivateAssets="all" />
+    <Compile Include="$(MSBuildThisFileDirectory)PackageManifestHints.cs" Link="PackageManifestHints.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/modules/PackageManifestHints.cs
+++ b/src/modules/PackageManifestHints.cs
@@ -1,0 +1,3 @@
+using Elsa.Platform.PackageManifest.Generator.Hints;
+
+[assembly: ManifestRuntimeKind(ElsaRuntimeKinds.Server)]

--- a/src/modules/scheduling/Elsa.Scheduling.Hangfire/ShellFeatures/HangfireShellFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Hangfire/ShellFeatures/HangfireShellFeature.cs
@@ -1,5 +1,5 @@
 using CShells.Features;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using JetBrains.Annotations;

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/ShellFeatures/QuartzMySqlFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/ShellFeatures/QuartzMySqlFeature.cs
@@ -1,6 +1,6 @@
 using CShells.Features;
 using CShells.Lifecycle;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Scheduling.Quartz.EFCore.MySql;
 using Elsa.Scheduling.Quartz.ShellFeatures;
 using JetBrains.Annotations;

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/ShellFeatures/QuartzPostgreSqlFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/ShellFeatures/QuartzPostgreSqlFeature.cs
@@ -1,6 +1,6 @@
 using CShells.Features;
 using CShells.Lifecycle;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Scheduling.Quartz.EFCore.PostgreSql;
 using Elsa.Scheduling.Quartz.ShellFeatures;
 using JetBrains.Annotations;

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/ShellFeatures/QuartzSqlServerFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/ShellFeatures/QuartzSqlServerFeature.cs
@@ -1,6 +1,6 @@
 using CShells.Features;
 using CShells.Lifecycle;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Scheduling.Quartz.EFCore.SqlServer;
 using Elsa.Scheduling.Quartz.ShellFeatures;
 using JetBrains.Annotations;

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/ShellFeatures/QuartzSqliteFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/ShellFeatures/QuartzSqliteFeature.cs
@@ -1,6 +1,6 @@
 using CShells.Features;
 using CShells.Lifecycle;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Scheduling.Quartz.EFCore.Sqlite;
 using Elsa.Scheduling.Quartz.ShellFeatures;
 using JetBrains.Annotations;

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzFeature.cs
@@ -1,6 +1,6 @@
 using CShells.Features;
 using CShells.Lifecycle;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Quartz;

--- a/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/ShellFeatures/AzureServiceBusShellFeature.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/ShellFeatures/AzureServiceBusShellFeature.cs
@@ -1,5 +1,5 @@
 using CShells.Features;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/modules/servicebus/Elsa.ServiceBus.Kafka/ShellFeatures/KafkaShellFeature.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.Kafka/ShellFeatures/KafkaShellFeature.cs
@@ -1,5 +1,5 @@
 using CShells.Features;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/modules/servicebus/Elsa.ServiceBus.MassTransit.AzureServiceBus/ShellFeatures/MassTransitAzureServiceBusFeature.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.MassTransit.AzureServiceBus/ShellFeatures/MassTransitAzureServiceBusFeature.cs
@@ -1,7 +1,7 @@
 using Azure.Messaging.ServiceBus.Administration;
 using CShells.Configuration;
 using CShells.Features;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.ServiceBus.MassTransit.AzureServiceBus.Configurators;
 using Elsa.ServiceBus.MassTransit.AzureServiceBus.Handlers;
 using Elsa.ServiceBus.MassTransit.AzureServiceBus.HostedServices;

--- a/src/modules/servicebus/Elsa.ServiceBus.MassTransit.RabbitMq/ShellFeatures/MassTransitRabbitMqFeature.cs
+++ b/src/modules/servicebus/Elsa.ServiceBus.MassTransit.RabbitMq/ShellFeatures/MassTransitRabbitMqFeature.cs
@@ -1,6 +1,6 @@
 using CShells.Configuration;
 using CShells.Features;
-using Elsa.PackageManifest.Generator.Hints;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.ServiceBus.MassTransit.Contracts;
 using Elsa.ServiceBus.MassTransit.RabbitMq.Configurators;
 using Elsa.ServiceBus.MassTransit.RabbitMq.Options;


### PR DESCRIPTION
## Summary
- Switch generator-backed module projects to `Elsa.Platform.PackageManifest.Generator`.
- Link a shared `PackageManifestHints.cs` into all `src/modules` projects with `ShellFeatures` so they emit `elsa.server` compatibility metadata.
- Update existing manifest hint usings to the Platform namespace.

## Testing
- Built all 31 `ShellFeatures` module projects for `net8.0` successfully.
- Verified the generated `elsa-package.json` files include `"compatibility.runtimeKinds": ["elsa.server"]`.
- No per-project override files were introduced.