### PR TITLE
Ensure durable Quartz job exists before scheduling its trigger

### DIFF
--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzWorkflowScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzWorkflowScheduler.cs
@@ -26,7 +26,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .StartAt(at)
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, cancellationToken);
+        await ScheduleJobAsync(scheduler, trigger, typeof(RunWorkflowJob), cancellationToken);
     }
 
     /// <inheritdoc />
@@ -40,7 +40,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .StartAt(at)
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, cancellationToken);
+        await ScheduleJobAsync(scheduler, trigger, typeof(ResumeWorkflowJob), cancellationToken);
     }
 
     /// <inheritdoc />
@@ -55,7 +55,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, cancellationToken);
+        await ScheduleJobAsync(scheduler, trigger, typeof(RunWorkflowJob), cancellationToken);
     }
 
     /// <inheritdoc />
@@ -70,7 +70,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, cancellationToken);
+        await ScheduleJobAsync(scheduler, trigger, typeof(ResumeWorkflowJob), cancellationToken);
     }
 
     /// <inheritdoc />
@@ -84,7 +84,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithCronSchedule(cronExpression)
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, cancellationToken);
+        await ScheduleJobAsync(scheduler, trigger, typeof(RunWorkflowJob), cancellationToken);
     }
 
     /// <inheritdoc />
@@ -97,7 +97,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithIdentity(GetTriggerKey(taskName))
             .WithCronSchedule(cronExpression).Build();
 
-        await ScheduleJobAsync(scheduler, trigger, cancellationToken);
+        await ScheduleJobAsync(scheduler, trigger, typeof(ResumeWorkflowJob), cancellationToken);
     }
 
     /// <inheritdoc />
@@ -108,8 +108,16 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
         await scheduler.UnscheduleJob(triggerKey, cancellationToken);
     }
     
-    private async Task ScheduleJobAsync(QuartzIScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken)
+    private async Task ScheduleJobAsync(QuartzIScheduler scheduler, ITrigger trigger, Type jobType, CancellationToken cancellationToken)
     {
+        // Ensure the durable job referenced by the trigger exists before scheduling.
+        // The job is normally registered at startup by RegisterJobsTask, but it can be absent here when:
+        // - the trigger targets a tenant-specific job group that was never registered at startup,
+        // - the startup task has not run yet (or was skipped), or
+        // - the job rows were removed from the Quartz job store at runtime.
+        // Without this, Quartz throws "The job (...RunWorkflowJob) referenced by the trigger does not exist".
+        await EnsureJobAsync(scheduler, trigger.JobKey, jobType, cancellationToken);
+
         try
         {
             // Try to schedule the trigger. In clustered mode, multiple instances may attempt this simultaneously.
@@ -124,6 +132,36 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             // when multiple pods attempt to schedule the same trigger during tenant activation or startup.
             // We can safely ignore this and continue, as the trigger is already scheduled.
             logger.LogDebug("Trigger {TriggerKey} already exists, skipping scheduling. This is expected in clustered deployments during concurrent operations", trigger.Key);
+        }
+    }
+
+    private async Task EnsureJobAsync(QuartzIScheduler scheduler, JobKey jobKey, Type jobType, CancellationToken cancellationToken)
+    {
+        // Fast path: the durable job is already registered.
+        if (await scheduler.CheckExists(jobKey, cancellationToken))
+            return;
+
+        var job = JobBuilder.Create(jobType)
+            .WithIdentity(jobKey)
+            .StoreDurably()
+            .Build();
+
+        try
+        {
+            // Use replace=false so we don't overwrite an existing job definition. In clustered mode,
+            // multiple instances may attempt this simultaneously between the CheckExists call and here.
+            const bool replaceExisting = false;
+            await scheduler.AddJob(job, replaceExisting, cancellationToken);
+        }
+        catch (JobPersistenceException e) when (e.InnerException is ObjectAlreadyExistsException)
+        {
+            // Job already exists, which is fine: another instance registered it concurrently.
+            logger.LogDebug("Job {JobKey} already exists, skipping registration. This is expected in clustered deployments during concurrent operations", jobKey);
+        }
+        catch (ObjectAlreadyExistsException)
+        {
+            // Job already exists, which is fine: another instance registered it concurrently.
+            logger.LogDebug("Job {JobKey} already exists, skipping registration. This is expected in clustered deployments during concurrent operations", jobKey);
         }
     }
 

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzWorkflowScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzWorkflowScheduler.cs
@@ -26,7 +26,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .StartAt(at)
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, typeof(RunWorkflowJob), cancellationToken);
+        await ScheduleJobAsync<RunWorkflowJob>(scheduler, trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -40,7 +40,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .StartAt(at)
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, typeof(ResumeWorkflowJob), cancellationToken);
+        await ScheduleJobAsync<ResumeWorkflowJob>(scheduler, trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -55,7 +55,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, typeof(RunWorkflowJob), cancellationToken);
+        await ScheduleJobAsync<RunWorkflowJob>(scheduler, trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -70,7 +70,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, typeof(ResumeWorkflowJob), cancellationToken);
+        await ScheduleJobAsync<ResumeWorkflowJob>(scheduler, trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -84,7 +84,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithCronSchedule(cronExpression)
             .Build();
 
-        await ScheduleJobAsync(scheduler, trigger, typeof(RunWorkflowJob), cancellationToken);
+        await ScheduleJobAsync<RunWorkflowJob>(scheduler, trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -97,7 +97,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
             .WithIdentity(GetTriggerKey(taskName))
             .WithCronSchedule(cronExpression).Build();
 
-        await ScheduleJobAsync(scheduler, trigger, typeof(ResumeWorkflowJob), cancellationToken);
+        await ScheduleJobAsync<ResumeWorkflowJob>(scheduler, trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -108,7 +108,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
         await scheduler.UnscheduleJob(triggerKey, cancellationToken);
     }
     
-    private async Task ScheduleJobAsync(QuartzIScheduler scheduler, ITrigger trigger, Type jobType, CancellationToken cancellationToken)
+    private async Task ScheduleJobAsync<TJob>(QuartzIScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken) where TJob : IJob
     {
         // Ensure the durable job referenced by the trigger exists before scheduling.
         // The job is normally registered at startup by RegisterJobsTask, but it can be absent here when:
@@ -116,7 +116,7 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
         // - the startup task has not run yet (or was skipped), or
         // - the job rows were removed from the Quartz job store at runtime.
         // Without this, Quartz throws "The job (...RunWorkflowJob) referenced by the trigger does not exist".
-        await EnsureJobAsync(scheduler, trigger.JobKey, jobType, cancellationToken);
+        await EnsureJobAsync<TJob>(scheduler, trigger.JobKey, cancellationToken);
 
         try
         {
@@ -135,13 +135,13 @@ public class QuartzWorkflowScheduler(ISchedulerFactory schedulerFactoryFactory, 
         }
     }
 
-    private async Task EnsureJobAsync(QuartzIScheduler scheduler, JobKey jobKey, Type jobType, CancellationToken cancellationToken)
+    private async Task EnsureJobAsync<TJob>(QuartzIScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken) where TJob : IJob
     {
         // Fast path: the durable job is already registered.
         if (await scheduler.CheckExists(jobKey, cancellationToken))
             return;
 
-        var job = JobBuilder.Create(jobType)
+        var job = JobBuilder.Create<TJob>()
             .WithIdentity(jobKey)
             .StoreDurably()
             .Build();

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzWorkflowSchedulerTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzWorkflowSchedulerTests.cs
@@ -1,0 +1,161 @@
+using Elsa.Common;
+using Elsa.Common.Multitenancy;
+using Elsa.Scheduling.Quartz.Jobs;
+using Elsa.Scheduling.Quartz.Services;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Quartz;
+
+namespace Elsa.Scheduling.Quartz.UnitTests.Services;
+
+/// <summary>
+/// Tests that <see cref="QuartzWorkflowScheduler"/> registers the durable job referenced by a trigger
+/// before scheduling it, so scheduling does not fail with "The job (...) referenced by the trigger does not exist".
+/// </summary>
+public class QuartzWorkflowSchedulerTests
+{
+    [Fact]
+    public async Task ScheduleCronAsync_WhenJobMissing_RegistersDurableJobThenSchedulesTrigger()
+    {
+        // Arrange
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = CreateNewRequest();
+
+        // Act
+        await sut.ScheduleCronAsync("task-1", request, "0 0/5 * * * ?");
+
+        // Assert: the durable RunWorkflowJob was added, then the trigger was scheduled.
+        scheduler.Verify(s => s.AddJob(
+            It.Is<IJobDetail>(j => j.Key.Name == nameof(RunWorkflowJob) && j.Durable),
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleCronAsync_WhenJobAlreadyExists_DoesNotAddJob()
+    {
+        // Arrange
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = CreateNewRequest();
+
+        // Act
+        await sut.ScheduleCronAsync("task-1", request, "0 0/5 * * * ?");
+
+        // Assert: no redundant registration, but the trigger is still scheduled.
+        scheduler.Verify(s => s.AddJob(It.IsAny<IJobDetail>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleCronAsync_RegistersJobInTenantSpecificGroup()
+    {
+        // Arrange
+        const string tenantId = "tenant-a";
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var sut = CreateScheduler(scheduler, out _, tenantId);
+        var request = CreateNewRequest();
+
+        // Act
+        await sut.ScheduleCronAsync("task-1", request, "0 0/5 * * * ?");
+
+        // Assert: the durable job is registered in the tenant's group, matching the trigger's job key.
+        scheduler.Verify(s => s.AddJob(
+            It.Is<IJobDetail>(j => j.Key.Group == tenantId && j.Key.Name == nameof(RunWorkflowJob)),
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleRecurringAsync_ExistingInstance_RegistersResumeWorkflowJob()
+    {
+        // Arrange
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = new global::Elsa.Scheduling.ScheduleExistingWorkflowInstanceRequest { WorkflowInstanceId = "instance-1" };
+
+        // Act
+        await sut.ScheduleRecurringAsync("task-1", request, DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+
+        // Assert
+        scheduler.Verify(s => s.AddJob(
+            It.Is<IJobDetail>(j => j.Key.Name == nameof(ResumeWorkflowJob) && j.Durable),
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleCronAsync_WhenJobAddedConcurrently_SwallowsAlreadyExists()
+    {
+        // Arrange: CheckExists reports missing, but a concurrent instance registers it first, so AddJob throws.
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        scheduler.Setup(s => s.AddJob(It.IsAny<IJobDetail>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ObjectAlreadyExistsException("job already exists"));
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = CreateNewRequest();
+
+        // Act + Assert: does not throw, and still schedules the trigger.
+        await sut.ScheduleCronAsync("task-1", request, "0 0/5 * * * ?");
+
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleCronAsync_WhenJobAddedConcurrentlyViaSqlStore_SwallowsWrappedPersistenceException()
+    {
+        // Arrange: SQL-backed Quartz stores (e.g. AdoJobStore) wrap the duplicate-insert error in a
+        // JobPersistenceException with an inner ObjectAlreadyExistsException rather than throwing the
+        // inner exception directly. Verify that EnsureJobAsync handles this wrapping case.
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        scheduler.Setup(s => s.AddJob(It.IsAny<IJobDetail>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new JobPersistenceException("job already exists", new ObjectAlreadyExistsException("duplicate")));
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = CreateNewRequest();
+
+        // Act + Assert: does not throw, and still schedules the trigger.
+        await sut.ScheduleCronAsync("task-1", request, "0 0/5 * * * ?");
+
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static QuartzWorkflowScheduler CreateScheduler(Mock<global::Quartz.IScheduler> scheduler, out Mock<global::Quartz.ISchedulerFactory> factory, string? tenantId = null)
+    {
+        factory = new Mock<global::Quartz.ISchedulerFactory>();
+        factory.Setup(f => f.GetScheduler(It.IsAny<CancellationToken>())).ReturnsAsync(scheduler.Object);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.Tenant).Returns(tenantId == null ? null : new Tenant { Id = tenantId });
+
+        var jobKeyProvider = new JobKeyProvider(tenantAccessor.Object);
+        var jsonSerializer = new Mock<IJsonSerializer>();
+
+        return new QuartzWorkflowScheduler(
+            factory.Object,
+            jsonSerializer.Object,
+            tenantAccessor.Object,
+            jobKeyProvider,
+            NullLogger<QuartzWorkflowScheduler>.Instance);
+    }
+
+    private static global::Elsa.Scheduling.ScheduleNewWorkflowInstanceRequest CreateNewRequest() => new()
+    {
+        WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionVersionId("definition-version-1"),
+        TriggerActivityId = "activity-1"
+    };
+}

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzWorkflowSchedulerTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzWorkflowSchedulerTests.cs
@@ -97,6 +97,48 @@ public class QuartzWorkflowSchedulerTests
     }
 
     [Fact]
+    public async Task ScheduleAtAsync_NewInstance_RegistersRunWorkflowJob()
+    {
+        // Arrange
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = CreateNewRequest();
+
+        // Act
+        await sut.ScheduleAtAsync("task-1", request, DateTimeOffset.UtcNow);
+
+        // Assert
+        scheduler.Verify(s => s.AddJob(
+            It.Is<IJobDetail>(j => j.Key.Name == nameof(RunWorkflowJob) && j.Durable),
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScheduleAtAsync_ExistingInstance_RegistersResumeWorkflowJob()
+    {
+        // Arrange
+        var scheduler = new Mock<global::Quartz.IScheduler>();
+        scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var sut = CreateScheduler(scheduler, out _);
+        var request = new global::Elsa.Scheduling.ScheduleExistingWorkflowInstanceRequest { WorkflowInstanceId = "instance-1" };
+
+        // Act
+        await sut.ScheduleAtAsync("task-1", request, DateTimeOffset.UtcNow);
+
+        // Assert
+        scheduler.Verify(s => s.AddJob(
+            It.Is<IJobDetail>(j => j.Key.Name == nameof(ResumeWorkflowJob) && j.Durable),
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task ScheduleCronAsync_WhenJobAddedConcurrently_SwallowsAlreadyExists()
     {
         // Arrange: CheckExists reports missing, but a concurrent instance registers it first, so AddJob throws.


### PR DESCRIPTION
## Summary
- Port #160 to release/3.7.0
- Ensure Quartz durable jobs are present before scheduling triggers
- Add regression coverage for missing, tenant-specific, existing, and concurrent durable job registration paths

## Tests
- dotnet test test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Elsa.Scheduling.Quartz.UnitTests.csproj --no-restore --logger "console;verbosity=minimal"