### PR TITLE
build: bump NuGet.Packaging to 7.9.0 to unbreak the NUKE build on SDK 10.0.400

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -24,7 +24,7 @@
 
   <!--Overridden for vulnerability reasons with dependencies referencing older versions.-->
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="7.0.3" />
+    <PackageReference Include="NuGet.Packaging" Version="7.9.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

NUKE project evaluation fails on .NET SDK 10.0.400 before tests run:

    InvalidProjectFileException: The expression
    "[MSBuild]::GetTargetFrameworkIdentifier(net10.0)" cannot be evaluated.
    Could not load file or assembly 'NuGet.Frameworks, Version=7.9.0.0'.
    The located assembly's manifest definition does not match the assembly reference.

## Cause

The NUKE project pins NuGet.Packaging 7.0.3, which brings an app-local NuGet.Frameworks 7.0.3 into the build output. SDK 10.0.400 MSBuild requires NuGet.Frameworks 7.9.0.0, so the older app-local assembly shadows the SDK copy and fails assembly binding.

## Expected behavior

NUKE should evaluate net10.0 projects and execute build targets under SDK 10.0.400.

## Change

Bump NuGet.Packaging to 7.9.0 so the NuGet assembly family is compatible with the current SDK. No workflow, product, or API changes are included.

## Verification

- ./build.sh --help succeeds locally on .NET SDK 10.0.302 with zero build errors.
- Restore resolves both NuGet.Packaging and NuGet.Frameworks to 7.9.0.
- The PR workflow includes 10.x and will validate the current SDK band.

## Related

Mirrors elsa-workflows/elsa-core#7919, which fixed the same SDK 10.0.400 failure in Elsa Core.
