### PR TITLE
feat(scheduling): add configureDbContextOptions callback to Quartz EF…

### DIFF
--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/MySqlQuartzExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/MySqlQuartzExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Elsa.Scheduling.Quartz.EFCore.MySql;
+using Elsa.Scheduling.Quartz.EFCore.MySql;
 using Elsa.Scheduling.Quartz.Features;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -17,12 +17,17 @@ public static class MySqlQuartzExtensions
     /// <summary>
     /// Configures the <see cref="QuartzFeature"/> to use the MySQL job store.
     /// </summary>
-    public static QuartzFeature UseMySql(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useClustering = true, bool useContextPooling = false)
+    /// <param name="feature">The Quartz feature to configure.</param>
+    /// <param name="connectionString">The MySQL connection string.</param>
+    /// <param name="useClustering">Whether to enable Quartz clustering.</param>
+    /// <param name="useContextPooling">Whether to use DbContext pooling.</param>
+    /// <param name="configureDbContextOptions">An optional callback to further configure the <see cref="DbContextOptionsBuilder"/>, e.g. to apply a naming convention or set a custom migrations history table.</param>
+    public static QuartzFeature UseMySql(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useClustering = true, bool useContextPooling = false, Action<DbContextOptionsBuilder>? configureDbContextOptions = null)
     {
         if (useContextPooling)
-            feature.Services.AddPooledDbContextFactory<MySqlQuartzDbContext>(options => UseMySql(connectionString, options));
+            feature.Services.AddPooledDbContextFactory<MySqlQuartzDbContext>(options => UseMySql(connectionString, options, configureDbContextOptions));
         else
-            feature.Services.AddDbContextFactory<MySqlQuartzDbContext>(options => UseMySql(connectionString, options));
+            feature.Services.AddDbContextFactory<MySqlQuartzDbContext>(options => UseMySql(connectionString, options, configureDbContextOptions));
 
         feature.ConfigureQuartz += quartz =>
         {
@@ -41,9 +46,11 @@ public static class MySqlQuartzExtensions
         return feature;
     }
 
-    private static void UseMySql(string connectionString, DbContextOptionsBuilder options)
+    private static void UseMySql(string connectionString, DbContextOptionsBuilder options, Action<DbContextOptionsBuilder>? configureDbContextOptions)
     {
         // Use MySQL migrations.
         options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), sqlServerDbContextOptionsBuilder => { sqlServerDbContextOptionsBuilder.MigrationsAssembly(typeof(MySqlQuartzDbContext).Assembly.GetName().Name); });
+
+        configureDbContextOptions?.Invoke(options);
     }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/MySqlQuartzExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/MySqlQuartzExtensions.cs
@@ -48,8 +48,7 @@ public static class MySqlQuartzExtensions
 
     private static void UseMySql(string connectionString, DbContextOptionsBuilder options, Action<DbContextOptionsBuilder>? configureDbContextOptions)
     {
-        // Use MySQL migrations.
-        options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), sqlServerDbContextOptionsBuilder => { sqlServerDbContextOptionsBuilder.MigrationsAssembly(typeof(MySqlQuartzDbContext).Assembly.GetName().Name); });
+        options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), mySqlDbContextOptionsBuilder => { mySqlDbContextOptionsBuilder.MigrationsAssembly(typeof(MySqlQuartzDbContext).Assembly.GetName().Name); });
 
         configureDbContextOptions?.Invoke(options);
     }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/ShellFeatures/QuartzMySqlFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.MySql/ShellFeatures/QuartzMySqlFeature.cs
@@ -49,6 +49,9 @@ public class QuartzMySqlFeature : IShellFeature
         RestartRequired = true)]
     public bool UseContextPooling { get; set; }
 
+    /// <summary>An optional callback to configure the <see cref="DbContextOptionsBuilder"/>.</summary>
+    public Action<DbContextOptionsBuilder>? ConfigureDbContextOptions { get; set; }
+
     public void ConfigureServices(IServiceCollection services)
     {
         if (UseContextPooling)
@@ -71,9 +74,12 @@ public class QuartzMySqlFeature : IShellFeature
         });
     }
 
-    private void Configure(DbContextOptionsBuilder options) =>
+    private void Configure(DbContextOptionsBuilder options)
+    {
         options.UseMySql(ConnectionString, ServerVersion.AutoDetect(ConnectionString), mysql =>
             mysql.MigrationsAssembly(typeof(MySqlQuartzDbContext).Assembly.GetName().Name));
+        ConfigureDbContextOptions?.Invoke(options);
+    }
 }
 
 

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/PostgreSqlQuartzExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/PostgreSqlQuartzExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Elsa.Scheduling.Quartz.EFCore.PostgreSql;
+using Elsa.Scheduling.Quartz.EFCore.PostgreSql;
 using Elsa.Scheduling.Quartz.Features;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -17,12 +17,17 @@ public static class PostgreSqlQuartzExtensions
     /// <summary>
     /// Configures the <see cref="QuartzFeature"/> to use the PostgreSQL job store.
     /// </summary>
-    public static QuartzFeature UsePostgreSql(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useClustering = true, bool useContextPooling = false)
+    /// <param name="feature">The Quartz feature to configure.</param>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    /// <param name="useClustering">Whether to enable Quartz clustering.</param>
+    /// <param name="useContextPooling">Whether to use DbContext pooling.</param>
+    /// <param name="configureDbContextOptions">An optional callback to further configure the <see cref="DbContextOptionsBuilder"/>, e.g. to apply a naming convention or set a custom migrations history table.</param>
+    public static QuartzFeature UsePostgreSql(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useClustering = true, bool useContextPooling = false, Action<DbContextOptionsBuilder>? configureDbContextOptions = null)
     {
         if (useContextPooling)
-            feature.Services.AddPooledDbContextFactory<PostgreSqlQuartzDbContext>(options => UseNpgsql(connectionString, options));
+            feature.Services.AddPooledDbContextFactory<PostgreSqlQuartzDbContext>(options => UseNpgsql(connectionString, options, configureDbContextOptions));
         else
-            feature.Services.AddDbContextFactory<PostgreSqlQuartzDbContext>(options => UseNpgsql(connectionString, options));
+            feature.Services.AddDbContextFactory<PostgreSqlQuartzDbContext>(options => UseNpgsql(connectionString, options, configureDbContextOptions));
 
         feature.ConfigureQuartz += quartz =>
         {
@@ -46,9 +51,11 @@ public static class PostgreSqlQuartzExtensions
         return feature;
     }
 
-    private static void UseNpgsql(string connectionString, DbContextOptionsBuilder options)
+    private static void UseNpgsql(string connectionString, DbContextOptionsBuilder options, Action<DbContextOptionsBuilder>? configureDbContextOptions)
     {
         // Use PostgreSQL migrations.
         options.UseNpgsql(connectionString, sqlServerDbContextOptionsBuilder => { sqlServerDbContextOptionsBuilder.MigrationsAssembly(typeof(PostgreSqlQuartzDbContext).Assembly.GetName().Name); });
+
+        configureDbContextOptions?.Invoke(options);
     }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/ShellFeatures/QuartzPostgreSqlFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.PostgreSql/ShellFeatures/QuartzPostgreSqlFeature.cs
@@ -49,6 +49,9 @@ public class QuartzPostgreSqlFeature : IShellFeature
         RestartRequired = true)]
     public bool UseContextPooling { get; set; }
 
+    /// <summary>An optional callback to configure the <see cref="DbContextOptionsBuilder"/>.</summary>
+    public Action<DbContextOptionsBuilder>? ConfigureDbContextOptions { get; set; }
+
     public void ConfigureServices(IServiceCollection services)
     {
         if (UseContextPooling)
@@ -75,9 +78,12 @@ public class QuartzPostgreSqlFeature : IShellFeature
         });
     }
 
-    private void Configure(DbContextOptionsBuilder options) =>
+    private void Configure(DbContextOptionsBuilder options)
+    {
         options.UseNpgsql(ConnectionString, npgsql =>
             npgsql.MigrationsAssembly(typeof(PostgreSqlQuartzDbContext).Assembly.GetName().Name));
+        ConfigureDbContextOptions?.Invoke(options);
+    }
 }
 
 /// Runs EF Core migrations before the Quartz scheduler starts on shell activation.

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/ShellFeatures/QuartzSqlServerFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/ShellFeatures/QuartzSqlServerFeature.cs
@@ -49,6 +49,9 @@ public class QuartzSqlServerFeature : IShellFeature
         RestartRequired = true)]
     public bool UseContextPooling { get; set; }
 
+    /// <summary>An optional callback to configure the <see cref="DbContextOptionsBuilder"/>.</summary>
+    public Action<DbContextOptionsBuilder>? ConfigureDbContextOptions { get; set; }
+
     public void ConfigureServices(IServiceCollection services)
     {
         if (UseContextPooling)
@@ -77,9 +80,12 @@ public class QuartzSqlServerFeature : IShellFeature
         });
     }
 
-    private void Configure(DbContextOptionsBuilder options) =>
+    private void Configure(DbContextOptionsBuilder options)
+    {
         options.UseSqlServer(ConnectionString, sql =>
             sql.MigrationsAssembly(typeof(SqlServerQuartzDbContext).Assembly.GetName().Name));
+        ConfigureDbContextOptions?.Invoke(options);
+    }
 }
 
 /// Runs EF Core migrations before the Quartz scheduler starts on shell activation.

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/SqlServerQuartzExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.SqlServer/SqlServerQuartzExtensions.cs
@@ -17,12 +17,17 @@ public static class SqlServerQuartzExtensions
     /// <summary>
     /// Configures the <see cref="QuartzFeature"/> to use the SQL Server job store.
     /// </summary>
-    public static QuartzFeature UseSqlServer(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useClustering = true, bool useContextPooling = false)
+    /// <param name="feature">The Quartz feature to configure.</param>
+    /// <param name="connectionString">The SQL Server connection string.</param>
+    /// <param name="useClustering">Whether to enable Quartz clustering.</param>
+    /// <param name="useContextPooling">Whether to use DbContext pooling.</param>
+    /// <param name="configureDbContextOptions">An optional callback to further configure the <see cref="DbContextOptionsBuilder"/>, e.g. to apply a naming convention or set a custom migrations history table.</param>
+    public static QuartzFeature UseSqlServer(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useClustering = true, bool useContextPooling = false, Action<DbContextOptionsBuilder>? configureDbContextOptions = null)
     {
         if (useContextPooling)
-            feature.Services.AddPooledDbContextFactory<SqlServerQuartzDbContext>(options => UseSqlServer(connectionString, options));
+            feature.Services.AddPooledDbContextFactory<SqlServerQuartzDbContext>(options => UseSqlServer(connectionString, options, configureDbContextOptions));
         else
-            feature.Services.AddDbContextFactory<SqlServerQuartzDbContext>(options => UseSqlServer(connectionString, options));
+            feature.Services.AddDbContextFactory<SqlServerQuartzDbContext>(options => UseSqlServer(connectionString, options, configureDbContextOptions));
 
         feature.ConfigureQuartz += quartz =>
         {
@@ -45,9 +50,11 @@ public static class SqlServerQuartzExtensions
         return feature;
     }
 
-    private static void UseSqlServer(string connectionString, DbContextOptionsBuilder options)
+    private static void UseSqlServer(string connectionString, DbContextOptionsBuilder options, Action<DbContextOptionsBuilder>? configureDbContextOptions)
     {
         // Use SQL Server migrations.
         options.UseSqlServer(connectionString, sqlServerDbContextOptionsBuilder => { sqlServerDbContextOptionsBuilder.MigrationsAssembly(typeof(SqlServerQuartzDbContext).Assembly.GetName().Name); });
+
+        configureDbContextOptions?.Invoke(options);
     }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/ShellFeatures/QuartzSqliteFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/ShellFeatures/QuartzSqliteFeature.cs
@@ -53,6 +53,9 @@ public class QuartzSqliteFeature : IShellFeature, IPostConfigureShellServices
         RestartRequired = true)]
     public bool UseContextPooling { get; set; }
 
+    /// <summary>An optional callback to configure the <see cref="DbContextOptionsBuilder"/>.</summary>
+    public Action<DbContextOptionsBuilder>? ConfigureDbContextOptions { get; set; }
+
     public void ConfigureServices(IServiceCollection services)
     {
         if (UseContextPooling)
@@ -78,9 +81,12 @@ public class QuartzSqliteFeature : IShellFeature, IPostConfigureShellServices
         });
     }
 
-    private void Configure(DbContextOptionsBuilder options) =>
+    private void Configure(DbContextOptionsBuilder options)
+    {
         options.UseSqlite(ConnectionString, sqlite =>
             sqlite.MigrationsAssembly(typeof(SqliteQuartzDbContext).Assembly.GetName().Name));
+        ConfigureDbContextOptions?.Invoke(options);
+    }
 }
 
 /// Runs EF Core migrations before the Quartz scheduler starts on shell activation.

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/SqliteQuartzExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz.EFCore.Sqlite/SqliteQuartzExtensions.cs
@@ -17,12 +17,17 @@ public static class SqliteQuartzExtensions
     /// <summary>
     /// Configures the <see cref="QuartzFeature"/> to use the SQLite job store.
     /// </summary>
-    public static QuartzFeature UseSqlite(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useContextPooling = false, bool useClustering = false)
+    /// <param name="feature">The Quartz feature to configure.</param>
+    /// <param name="connectionString">The SQLite connection string.</param>
+    /// <param name="useContextPooling">Whether to use DbContext pooling.</param>
+    /// <param name="useClustering">Whether to enable Quartz clustering.</param>
+    /// <param name="configureDbContextOptions">An optional callback to further configure the <see cref="DbContextOptionsBuilder"/>, e.g. to apply a naming convention or set a custom migrations history table.</param>
+    public static QuartzFeature UseSqlite(this QuartzFeature feature, string connectionString = Constants.DefaultConnectionString, bool useContextPooling = false, bool useClustering = false, Action<DbContextOptionsBuilder>? configureDbContextOptions = null)
     {
         if (useContextPooling)
-            feature.Services.AddPooledDbContextFactory<SqliteQuartzDbContext>(options => UseSqlite(connectionString, options));
+            feature.Services.AddPooledDbContextFactory<SqliteQuartzDbContext>(options => UseSqlite(connectionString, options, configureDbContextOptions));
         else
-            feature.Services.AddDbContextFactory<SqliteQuartzDbContext>(options => UseSqlite(connectionString, options));
+            feature.Services.AddDbContextFactory<SqliteQuartzDbContext>(options => UseSqlite(connectionString, options, configureDbContextOptions));
 
         feature.ConfigureQuartz += quartz =>
         {
@@ -41,9 +46,11 @@ public static class SqliteQuartzExtensions
         return feature;
     }
 
-    private static void UseSqlite(string connectionString, DbContextOptionsBuilder options)
+    private static void UseSqlite(string connectionString, DbContextOptionsBuilder options, Action<DbContextOptionsBuilder>? configureDbContextOptions)
     {
         // Use SQLite migrations.
         options.UseSqlite(connectionString, sqlite => { sqlite.MigrationsAssembly(typeof(SqliteQuartzDbContext).Assembly.GetName().Name); });
+
+        configureDbContextOptions?.Invoke(options);
     }
 }


### PR DESCRIPTION
## 1. Problem Statement

When using Elsa Workflows with Quartz EF Core persistence (`UsePostgreSql`, `UseSqlServer`, `UseMySql`, or `UseSqlite`), there was previously no hook to configure the underlying `DbContextOptionsBuilder` used by the Quartz `DbContext`.

In real-world applications, this can cause issues when:

1. EF Core naming conventions are configured (for example, `options.UseSnakeCaseNamingConvention()` or `options.UseCamelCaseNamingConvention()`).
2. Custom migrations history table names or schemas are specified (for example, via `MigrationsHistoryTable(...)`).
3. Custom EF Core warnings, interceptors, or execution strategies are required.

Without a way to customize the Quartz `DbContextOptionsBuilder`, the Quartz `DbContext` and application `DbContext`s can collide over the shared default `__EFMigrationsHistory` table or fail with errors.

---

## 2. Expected vs. Actual Behavior

### Expected Behavior

Callers should be able to pass custom `DbContextOptionsBuilder` configurations (such as naming conventions or custom migrations history table names) to the Quartz `DbContext` factory, just like other Elsa EF Core modules.

### Actual Behavior

The Quartz EF Core extensions only accepted:

* `connectionString`
* `useClustering`
* `useContextPooling`

There was no way to customize the underlying `DbContextOptionsBuilder`.

---

## 3. Proposed Solution

Added an optional callback parameter:

```csharp
Action<DbContextOptionsBuilder>? configureDbContextOptions = null
```

to all four Quartz EF Core provider extension methods:

* `PostgreSqlQuartzExtensions.UsePostgreSql`
* `SqlServerQuartzExtensions.UseSqlServer`
* `MySqlQuartzExtensions.UseMySql`
* `SqliteQuartzExtensions.UseSqlite`

The matching property was also added to their respective Shell Features:

* `QuartzPostgreSqlFeature.ConfigureDbContextOptions`
* `QuartzSqlServerFeature.ConfigureDbContextOptions`
* `QuartzMySqlFeature.ConfigureDbContextOptions`
* `QuartzSqliteFeature.ConfigureDbContextOptions`

The callback is invoked immediately after the provider-specific configuration (for example, `options.UseNpgsql(...)`). This allows callers to further customize the `DbContextOptionsBuilder` without changing Quartz's existing underlying behavior.

---

## 4. Usage Examples

### Custom Migrations History Table

```csharp
elsa.UseQuartz(quartz =>
{
    quartz.UsePostgreSql(
        connectionString,
        configureDbContextOptions: options =>
        {
            options.UseNpgsql(sql =>
                sql.MigrationsHistoryTable(
                    "__QuartzMigrationsHistory",
                    "quartz"));
        }
    );
});
```

### EF Core Naming Conventions

```csharp
elsa.UseQuartz(quartz =>
{
    quartz.UsePostgreSql(
        connectionString,
        configureDbContextOptions: options =>
        {
            options.UseSnakeCaseNamingConvention();
        }
    );
});
```

---

## 5. Verification & Testing

* ✅ **Build verification:** Build succeeds with **0 errors and 0 warnings** across target frameworks:

  * `net8.0`
  * `net9.0`
  * `net10.0`

  for all four provider projects:

  * `Elsa.Scheduling.Quartz.EFCore.PostgreSql`
  * `Elsa.Scheduling.Quartz.EFCore.SqlServer`
  * `Elsa.Scheduling.Quartz.EFCore.MySql`
  * `Elsa.Scheduling.Quartz.EFCore.Sqlite`

* ✅ **Runtime verification:**

  * Quartz migrations successfully apply using a custom-configured migrations history table.
  * The Quartz scheduler starts successfully and runs jobs as expected with PostgreSQL persistence. Other providers have not been tested.

---

## 6. Compatibility & Scope

* ✅ **100% non-breaking and backwards-compatible:** All new parameters default to `null`.
* ✅ **Zero additional dependencies:** Uses the existing `Microsoft.EntityFrameworkCore.DbContextOptionsBuilder`.
* ✅ **One PR = One Concern:** This change strictly addresses `DbContextOptionsBuilder` configurability across the EF Core Quartz providers.
