### PR TITLE
Support workflow label filtering with MongoDB

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
 	</PropertyGroup>
     
     <PropertyGroup Label="PackageVersions">
-        <ElsaVersion>3.8.0</ElsaVersion>
+        <ElsaVersion>3.8.0-preview.5557</ElsaVersion>
         <ElsaStudioVersion>3.8.0</ElsaStudioVersion>
     </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -237,6 +237,7 @@
         <PackageVersion Include="System.Memory.Data" Version="10.0.3"/>
         <PackageVersion Include="System.Text.Json" Version="10.0.9"/>
         <PackageVersion Include="Testcontainers" Version="4.9.0"/>
+        <PackageVersion Include="Testcontainers.MongoDb" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.PostgreSql" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.RabbitMq" Version="4.9.0"/>
         <PackageVersion Include="ThrottleDebounce" Version="2.0.1"/>

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Labels/CreateIndices.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Labels/CreateIndices.cs
@@ -31,7 +31,8 @@ internal class CreateIndices(IServiceProvider serviceProvider) : IHostedService
                     new List<CreateIndexModel<WorkflowDefinitionLabel>>
                     {
                         new(indexBuilder.Ascending(x => x.WorkflowDefinitionId)),
-                        new(indexBuilder.Ascending(x => x.WorkflowDefinitionVersionId))
+                        new(indexBuilder.Ascending(x => x.WorkflowDefinitionVersionId)),
+                        new(indexBuilder.Ascending(x => x.LabelId))
                     },
                     cancellationToken));
     }

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Labels/WorkflowDefinitionLabelStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Labels/WorkflowDefinitionLabelStore.cs
@@ -7,7 +7,7 @@ namespace Elsa.Persistence.MongoDb.Modules.Labels;
 
 /// <inheritdoc />
 [UsedImplicitly]
-public class MongoWorkflowDefinitionLabelStore(MongoDbStore<WorkflowDefinitionLabel> mongoDbStore) : IWorkflowDefinitionLabelStore
+public class MongoWorkflowDefinitionLabelStore(MongoDbStore<WorkflowDefinitionLabel> mongoDbStore) : IWorkflowDefinitionLabelStore, IWorkflowDefinitionLabelQuery
 {
     /// <inheritdoc />
     public Task SaveAsync(WorkflowDefinitionLabel record, CancellationToken cancellationToken = default)
@@ -31,6 +31,18 @@ public class MongoWorkflowDefinitionLabelStore(MongoDbStore<WorkflowDefinitionLa
     public Task<IEnumerable<WorkflowDefinitionLabel>> FindByWorkflowDefinitionVersionIdAsync(string workflowDefinitionVersionId, CancellationToken cancellationToken = default)
     {
         return mongoDbStore.FindManyAsync(x => x.WorkflowDefinitionVersionId == workflowDefinitionVersionId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<WorkflowDefinitionLabel>> FindByLabelIdsAsync(IEnumerable<string> labelIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(labelIds);
+
+        var ids = labelIds.Distinct().ToList();
+
+        return ids.Count == 0
+            ? Task.FromResult<IEnumerable<WorkflowDefinitionLabel>>(Array.Empty<WorkflowDefinitionLabel>())
+            : mongoDbStore.FindManyAsync(x => ids.Contains(x.LabelId), cancellationToken);
     }
 
     /// <inheritdoc />

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/Elsa.MongoDb.UnitTests.csproj
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/Elsa.MongoDb.UnitTests.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Testcontainers.MongoDb" />
 	  <ProjectReference Include="..\..\..\..\src\modules\persistence\Elsa.Persistence.MongoDb\Elsa.Persistence.MongoDb.csproj" />
 	</ItemGroup>
 	

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowDefinitionLabelStoreTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowDefinitionLabelStoreTests.cs
@@ -13,20 +13,39 @@ public sealed class MongoWorkflowDefinitionLabelStoreTests : IAsyncLifetime
 {
     private readonly MongoDbContainer _container = new MongoDbBuilder().WithImage("mongo:7.0.24").Build();
     private readonly TestTenantAccessor _tenantAccessor = new();
+    private MongoClient? _client;
     private MongoWorkflowDefinitionLabelStore _store = null!;
 
     public async Task InitializeAsync()
     {
-        await _container.StartAsync();
+        try
+        {
+            await _container.StartAsync();
 
-        var client = new MongoClient(_container.GetConnectionString());
-        var database = client.GetDatabase($"elsa-labels-{Guid.NewGuid():N}");
-        var collection = database.GetCollection<WorkflowDefinitionLabel>("workflow_definition_labels");
-        var mongoDbStore = new MongoDbStore<WorkflowDefinitionLabel>(collection, _tenantAccessor);
-        _store = new MongoWorkflowDefinitionLabelStore(mongoDbStore);
+            _client = new MongoClient(_container.GetConnectionString());
+            var database = _client.GetDatabase($"elsa-labels-{Guid.NewGuid():N}");
+            var collection = database.GetCollection<WorkflowDefinitionLabel>("workflow_definition_labels");
+            var mongoDbStore = new MongoDbStore<WorkflowDefinitionLabel>(collection, _tenantAccessor);
+            _store = new MongoWorkflowDefinitionLabelStore(mongoDbStore);
+        }
+        catch
+        {
+            await DisposeAsync();
+            throw;
+        }
     }
 
-    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            _client?.Dispose();
+        }
+        finally
+        {
+            await _container.DisposeAsync();
+        }
+    }
 
     [Fact]
     public async Task FindByLabelIdsAsync_ReturnsAnyMatchingVersionForCurrentTenant()

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowDefinitionLabelStoreTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowDefinitionLabelStoreTests.cs
@@ -1,0 +1,106 @@
+using Elsa.Common.Multitenancy;
+using Elsa.Labels.Services;
+using Elsa.Persistence.MongoDb.Common;
+using Elsa.Persistence.MongoDb.Modules.Labels;
+using Elsa.Workflows.Management.Filters;
+using MongoDB.Driver;
+using Testcontainers.MongoDb;
+using WorkflowDefinitionLabel = Elsa.Labels.Entities.WorkflowDefinitionLabel;
+
+namespace Elsa.MongoDb.UnitTests;
+
+public sealed class MongoWorkflowDefinitionLabelStoreTests : IAsyncLifetime
+{
+    private readonly MongoDbContainer _container = new MongoDbBuilder().WithImage("mongo:7.0.24").Build();
+    private readonly TestTenantAccessor _tenantAccessor = new();
+    private MongoWorkflowDefinitionLabelStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        var client = new MongoClient(_container.GetConnectionString());
+        var database = client.GetDatabase($"elsa-labels-{Guid.NewGuid():N}");
+        var collection = database.GetCollection<WorkflowDefinitionLabel>("workflow_definition_labels");
+        var mongoDbStore = new MongoDbStore<WorkflowDefinitionLabel>(collection, _tenantAccessor);
+        _store = new MongoWorkflowDefinitionLabelStore(mongoDbStore);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task FindByLabelIdsAsync_ReturnsAnyMatchingVersionForCurrentTenant()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        await SaveAsync(
+            Record("association-a1", "definition-a", "version-a1", "label-a"),
+            Record("association-a2", "definition-a", "version-a2", "label-b"),
+            Record("association-a3", "definition-b", "version-b1", "label-c"));
+
+        using var otherTenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-b" });
+        await SaveAsync(Record("association-b1", "definition-b", "version-b1", "label-a"));
+
+        using var queryTenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var results = await _store.FindByLabelIdsAsync(["label-a", "label-b"]);
+
+        Assert.Equal(["version-a1", "version-a2"], results.Select(x => x.WorkflowDefinitionVersionId).OrderBy(x => x));
+        Assert.All(results, result => Assert.Equal("tenant-a", result.TenantId));
+    }
+
+    [Fact]
+    public async Task FindByLabelIdsAsync_ReturnsNoRowsForEmptyOrUnknownLabelIds()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        await SaveAsync(Record("association-a1", "definition-a", "version-a1", "label-a"));
+
+        Assert.Empty(await _store.FindByLabelIdsAsync([]));
+        Assert.Empty(await _store.FindByLabelIdsAsync(["missing-label"]));
+    }
+
+    [Fact]
+    public async Task WorkflowDefinitionLabelFilterProvider_AppliesAnyMatchingVersionIds()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        await SaveAsync(
+            Record("association-a1", "definition-a", "version-a1", "label-a"),
+            Record("association-a2", "definition-a", "version-a2", "label-b"));
+
+        var filter = new WorkflowDefinitionFilter { LabelIds = ["label-b", "missing-label"] };
+        var provider = new WorkflowDefinitionLabelFilterProvider(_store);
+
+        await provider.ApplyAsync(filter);
+
+        Assert.Equal(["version-a2"], filter.Ids);
+    }
+
+    private async Task SaveAsync(params WorkflowDefinitionLabel[] records)
+    {
+        await _store.SaveManyAsync(records);
+    }
+
+    private static WorkflowDefinitionLabel Record(string id, string workflowDefinitionId, string workflowDefinitionVersionId, string labelId) => new()
+    {
+        Id = id,
+        WorkflowDefinitionId = workflowDefinitionId,
+        WorkflowDefinitionVersionId = workflowDefinitionVersionId,
+        LabelId = labelId
+    };
+
+    private sealed class TestTenantAccessor : ITenantAccessor
+    {
+        public string TenantId => Tenant?.Id ?? Elsa.Common.Multitenancy.Tenant.DefaultTenantId;
+        public Tenant? Tenant { get; private set; }
+
+        public IDisposable PushContext(Tenant? tenant)
+        {
+            var previousTenant = Tenant;
+            Tenant = tenant;
+            return new Restore(() => Tenant = previousTenant);
+        }
+
+        private sealed class Restore(Action restore) : IDisposable
+        {
+            public void Dispose() => restore();
+        }
+    }
+}


### PR DESCRIPTION
MongoDB-backed hosts need the label-query capability introduced by [Elsa Core #8035](https://github.com/elsa-workflows/elsa-core/pull/8035) to filter workflow definitions by their labels. This adds tenant-scoped, any-label lookup of workflow-definition version associations and a `LabelId` index, completing the MongoDB portion of [elsa-workflows/elsa-core#7935](https://github.com/elsa-workflows/elsa-core/issues/7935).

The Elsa package set moves together to the published `3.8.0-preview.5557` build containing the reviewed Core change. The Studio package version remains `3.8.0`.

Validation: whole-solution restore, MongoDB module builds for .NET 8/9/10, and all four MongoDB tests, including three new tests against MongoDB 7.0.24. The live tests cover tenant isolation, any-label matching, empty/unknown IDs, version IDs, and the actual Core filter provider calling this adapter. Core's separate endpoint tests cover authorization, unsupported providers, pagination, totals, and ID intersection. The local Mongo tests do not run a complete HTTP host or assert index metadata.
