### PR TITLE
feat(quartz): retry transient job failures with bounded exponential backoff

### DIFF
--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Constants/QuartzJobDataKeys.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Constants/QuartzJobDataKeys.cs
@@ -1,0 +1,13 @@
+namespace Elsa.Scheduling.Quartz;
+
+/// <summary>
+/// Well-known keys written by this module into a Quartz <see cref="global::Quartz.JobDataMap"/>.
+/// </summary>
+public static class QuartzJobDataKeys
+{
+    /// <summary>
+    /// The key under which the one-based retry attempt number is stored on a rescheduled trigger. The value is stored
+    /// as a string so that job stores configured with <c>quartz.jobStore.useProperties</c> can persist it.
+    /// </summary>
+    public const string RetryAttempt = "Elsa.Scheduling.Quartz:RetryAttempt";
+}

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Contracts/IQuartzJobRetryScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Contracts/IQuartzJobRetryScheduler.cs
@@ -22,8 +22,9 @@ public interface IQuartzJobRetryScheduler
     /// <param name="exception">The exception the job failed with.</param>
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>
-    /// True if a retry was scheduled; false if retries are disabled or the configured maximum number of retries has
-    /// been exhausted, in which case the caller is responsible for reporting the failure.
+    /// True if a retry was scheduled; false if retries are disabled, the configured maximum number of retries has
+    /// been exhausted, or the original trigger was no longer present (so no replacement could be stored), in which
+    /// case the caller is responsible for reporting the failure.
     /// </returns>
     Task<bool> ScheduleRetryAsync(IJobExecutionContext context, Exception exception, CancellationToken cancellationToken = default);
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Contracts/IQuartzJobRetryScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Contracts/IQuartzJobRetryScheduler.cs
@@ -8,7 +8,22 @@ namespace Elsa.Scheduling.Quartz.Contracts;
 public interface IQuartzJobRetryScheduler
 {
     /// <summary>
-    /// Reschedules the trigger of the current job for a retry using the configured retry delay.
+    /// Determines whether a job that failed with the specified exception should be retried.
     /// </summary>
-    Task ScheduleRetryAsync(IJobExecutionContext context, CancellationToken cancellationToken = default);
+    /// <param name="exception">The exception the job failed with.</param>
+    /// <returns>True if the exception is worth retrying; otherwise, false.</returns>
+    bool IsRetryable(Exception exception);
+
+    /// <summary>
+    /// Reschedules the trigger of the current job for a retry, using the configured backoff policy. The attempt number
+    /// is carried over on the rescheduled trigger, together with the job data of the original trigger.
+    /// </summary>
+    /// <param name="context">The execution context of the attempt that just failed.</param>
+    /// <param name="exception">The exception the job failed with.</param>
+    /// <param name="cancellationToken">An optional cancellation token.</param>
+    /// <returns>
+    /// True if a retry was scheduled; false if retries are disabled or the configured maximum number of retries has
+    /// been exhausted, in which case the caller is responsible for reporting the failure.
+    /// </returns>
+    Task<bool> ScheduleRetryAsync(IJobExecutionContext context, Exception exception, CancellationToken cancellationToken = default);
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Contracts/IQuartzRetryDelayCalculator.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Contracts/IQuartzRetryDelayCalculator.cs
@@ -1,0 +1,17 @@
+using Elsa.Scheduling.Quartz.Options;
+
+namespace Elsa.Scheduling.Quartz.Contracts;
+
+/// <summary>
+/// Computes the delay before the next retry of a failed Quartz job.
+/// </summary>
+public interface IQuartzRetryDelayCalculator
+{
+    /// <summary>
+    /// Computes the delay before the specified retry attempt.
+    /// </summary>
+    /// <param name="attemptNumber">The one-based number of the retry to compute the delay for. The first retry is attempt 1.</param>
+    /// <param name="options">The options describing the backoff strategy to apply.</param>
+    /// <returns>The delay to wait before the specified retry. Never negative.</returns>
+    TimeSpan CalculateDelay(int attemptNumber, QuartzJobOptions options);
+}

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Extensions/JobExecutionExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Extensions/JobExecutionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Elsa.Common.Multitenancy;
 using Elsa.Scheduling.Quartz.Jobs;
 using Quartz;
@@ -6,6 +7,29 @@ namespace Elsa.Scheduling.Quartz;
 
 internal static class JobExecutionExtensions
 {
+    /// <summary>
+    /// Gets the number of retries that have already been scheduled for the currently executing trigger. Returns 0 when
+    /// the trigger is the original one, i.e. when the current execution is not a retry.
+    /// </summary>
+    /// <param name="context">The Quartz job execution context.</param>
+    public static int GetRetryAttempt(this IJobExecutionContext context)
+    {
+        var jobDataMap = context.Trigger.JobDataMap;
+
+        if (jobDataMap == null || !jobDataMap.TryGetValue(QuartzJobDataKeys.RetryAttempt, out var value))
+            return 0;
+
+        // The attempt is written as a string so that job stores using properties-only serialization can persist it,
+        // but a numeric value is accepted as well.
+        return value switch
+        {
+            int intValue => intValue,
+            long longValue => (int)longValue,
+            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue) => parsedValue,
+            _ => 0
+        };
+    }
+
     public static async Task<Tenant?> GetTenantAsync(this IJobExecutionContext context, ITenantFinder tenantFinder)
     {
         if(!context.MergedJobDataMap.ContainsKey("TenantId"))

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Extensions/JobExecutionExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Extensions/JobExecutionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Elsa.Common.Multitenancy;
+using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Scheduling.Quartz.Jobs;
 using Quartz;
 
@@ -7,6 +8,22 @@ namespace Elsa.Scheduling.Quartz;
 
 internal static class JobExecutionExtensions
 {
+    /// <summary>
+    /// Attempts to schedule a retry for the current job execution. Callers should return from their <c>catch</c>
+    /// block when this returns <c>true</c>; when it returns <c>false</c>, retries are exhausted and the caller is
+    /// responsible for logging its own workflow-specific error message.
+    /// </summary>
+    /// <param name="retryScheduler">The retry scheduler.</param>
+    /// <param name="context">The Quartz job execution context.</param>
+    /// <param name="exception">The exception the job failed with.</param>
+    /// <param name="cancellationToken">An optional cancellation token.</param>
+    /// <returns>True if a retry was scheduled; otherwise, false.</returns>
+    public static async Task<bool> TryScheduleRetryAsync(this IQuartzJobRetryScheduler retryScheduler, IJobExecutionContext context, Exception exception, CancellationToken cancellationToken = default)
+    {
+        // The retry scheduler logs the scheduled retry, including the attempt number and delay.
+        return await retryScheduler.ScheduleRetryAsync(context, exception, cancellationToken);
+    }
+
     /// <summary>
     /// Gets the number of retries that have already been scheduled for the currently executing trigger. Returns 0 when
     /// the trigger is the original one, i.e. when the current execution is not a retry.

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Extensions/JobExecutionExtensions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Extensions/JobExecutionExtensions.cs
@@ -41,8 +41,8 @@ internal static class JobExecutionExtensions
         return value switch
         {
             int intValue => intValue,
-            long longValue => (int)longValue,
-            string stringValue when int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue) => parsedValue,
+            long longValue => (int)Math.Clamp(longValue, int.MinValue, int.MaxValue),
+            string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue) => (int)Math.Clamp(parsedValue, int.MinValue, int.MaxValue),
             _ => 0
         };
     }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Features/QuartzSchedulerFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Features/QuartzSchedulerFeature.cs
@@ -54,6 +54,7 @@ public class QuartzSchedulerFeature(IModule module) : FeatureBase(module)
             .AddSingleton<QuartzCronParser>()
             .AddScoped<QuartzWorkflowScheduler>()
             .AddScoped<IJobKeyProvider, JobKeyProvider>()
+            .AddSingleton<IQuartzRetryDelayCalculator, QuartzRetryDelayCalculator>()
             .AddSingleton<IQuartzJobRetryScheduler, QuartzJobRetryScheduler>()
             .AddStartupTask<RegisterJobsTask>()
             .AddQuartz();

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/ResumeWorkflowJob.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/ResumeWorkflowJob.cs
@@ -24,17 +24,19 @@ public class ResumeWorkflowJob(
     /// <inheritdoc />
     public async Task Execute(IJobExecutionContext context)
     {
-        var tenant = await context.GetTenantAsync(tenantFinder);
-        using (tenantAccessor.PushContext(tenant))
-        {
-            var map = context.MergedJobDataMap;
-            var serializedActivityHandle = (string)map.Get(nameof(ScheduleExistingWorkflowInstanceRequest.ActivityHandle));
-            var activityHandle = serializedActivityHandle != null! ? jsonSerializer.Deserialize<ActivityHandle>(serializedActivityHandle) : null;
-            var workflowInstanceId = (string)map.Get(nameof(ScheduleExistingWorkflowInstanceRequest.WorkflowInstanceId));
-            var cancellationToken = context.CancellationToken;
+        var cancellationToken = context.CancellationToken;
+        string? workflowInstanceId = null;
 
-            try
+        try
+        {
+            var tenant = await context.GetTenantAsync(tenantFinder);
+            using (tenantAccessor.PushContext(tenant))
             {
+                var map = context.MergedJobDataMap;
+                var serializedActivityHandle = (string)map.Get(nameof(ScheduleExistingWorkflowInstanceRequest.ActivityHandle));
+                var activityHandle = serializedActivityHandle != null! ? jsonSerializer.Deserialize<ActivityHandle>(serializedActivityHandle) : null;
+                workflowInstanceId = (string)map.Get(nameof(ScheduleExistingWorkflowInstanceRequest.WorkflowInstanceId));
+
                 var workflowClient = await workflowRuntime.CreateClientAsync(workflowInstanceId, cancellationToken);
                 var request = new RunWorkflowInstanceRequest
                 {
@@ -47,23 +49,23 @@ public class ResumeWorkflowJob(
 
                 logger.LogInformation("Resumed workflow instance {WorkflowInstanceId}", workflowInstanceId);
             }
-            catch (Exception e) when (retryScheduler.IsRetryable(e))
-            {
-                if (await retryScheduler.TryScheduleRetryAsync(context, e, cancellationToken))
-                    return;
+        }
+        catch (Exception e) when (retryScheduler.IsRetryable(e))
+        {
+            if (await retryScheduler.TryScheduleRetryAsync(context, e, cancellationToken))
+                return;
 
-                logger.LogError(
-                    e,
-                    "Retries are exhausted for job {JobKey} after {RetryAttempts} retry attempt(s). Giving up on resuming workflow instance {WorkflowInstanceId}",
-                    context.JobDetail.Key,
-                    context.GetRetryAttempt(),
-                    workflowInstanceId);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "An error occurred while resuming workflow instance {WorkflowInstanceId}", workflowInstanceId);
-                await context.DeleteJob(context.JobDetail.Key, cancellationToken);
-            }
+            logger.LogError(
+                e,
+                "No retry was scheduled for job {JobKey} after {RetryAttempts} retry attempt(s) (retries disabled, exhausted, or trigger no longer present). Giving up on resuming workflow instance {WorkflowInstanceId}",
+                context.JobDetail.Key,
+                context.GetRetryAttempt(),
+                workflowInstanceId);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "An error occurred while resuming workflow instance {WorkflowInstanceId}", workflowInstanceId);
+            await context.DeleteJob(context.JobDetail.Key, cancellationToken);
         }
     }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/ResumeWorkflowJob.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/ResumeWorkflowJob.cs
@@ -49,8 +49,7 @@ public class ResumeWorkflowJob(
             }
             catch (Exception e) when (retryScheduler.IsRetryable(e))
             {
-                // The retry scheduler logs the scheduled retry, including the attempt number and delay.
-                if (await retryScheduler.ScheduleRetryAsync(context, e, cancellationToken))
+                if (await retryScheduler.TryScheduleRetryAsync(context, e, cancellationToken))
                     return;
 
                 logger.LogError(

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/ResumeWorkflowJob.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/ResumeWorkflowJob.cs
@@ -1,7 +1,6 @@
 using Elsa.Common;
 using Elsa.Common.Multitenancy;
 using Elsa.Extensions;
-using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime;
@@ -19,7 +18,6 @@ public class ResumeWorkflowJob(
     IJsonSerializer jsonSerializer,
     ITenantFinder tenantFinder,
     ITenantAccessor tenantAccessor,
-    ITransientExceptionDetector transientExceptionDetector,
     IQuartzJobRetryScheduler retryScheduler,
     ILogger<ResumeWorkflowJob> logger) : IJob
 {
@@ -49,10 +47,18 @@ public class ResumeWorkflowJob(
 
                 logger.LogInformation("Resumed workflow instance {WorkflowInstanceId}", workflowInstanceId);
             }
-            catch (Exception e) when (transientExceptionDetector.IsTransient(e))
+            catch (Exception e) when (retryScheduler.IsRetryable(e))
             {
-                logger.LogWarning(e, "A transient error occurred while resuming workflow instance {WorkflowInstanceId}. Rescheduling job for retry", workflowInstanceId);
-                await retryScheduler.ScheduleRetryAsync(context, cancellationToken);
+                // The retry scheduler logs the scheduled retry, including the attempt number and delay.
+                if (await retryScheduler.ScheduleRetryAsync(context, e, cancellationToken))
+                    return;
+
+                logger.LogError(
+                    e,
+                    "Retries are exhausted for job {JobKey} after {RetryAttempts} retry attempt(s). Giving up on resuming workflow instance {WorkflowInstanceId}",
+                    context.JobDetail.Key,
+                    context.GetRetryAttempt(),
+                    workflowInstanceId);
             }
             catch (Exception e)
             {

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/RunWorkflowJob.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/RunWorkflowJob.cs
@@ -24,25 +24,27 @@ public class RunWorkflowJob(
     /// <inheritdoc />
     public async Task Execute(IJobExecutionContext context)
     {
-        var tenant = await context.GetTenantAsync(tenantFinder);
-        using (tenantAccessor.PushContext(tenant))
+        var cancellationToken = context.CancellationToken;
+        StartWorkflowRequest? startRequest = null;
+
+        try
         {
-            var map = context.MergedJobDataMap;
-            var cancellationToken = context.CancellationToken;
-
-            var startRequest = new StartWorkflowRequest
+            var tenant = await context.GetTenantAsync(tenantFinder);
+            using (tenantAccessor.PushContext(tenant))
             {
-                WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionVersionId((string)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.WorkflowDefinitionHandle.DefinitionVersionId))),
-                CorrelationId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.CorrelationId)),
-                TriggerActivityId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.TriggerActivityId)),
-                Input = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Input)),
-                Variables = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Variables)),
-                Properties = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Properties)),
-                ParentId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.ParentId))
-            };
+                var map = context.MergedJobDataMap;
 
-            try
-            {
+                startRequest = new StartWorkflowRequest
+                {
+                    WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionVersionId((string)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.WorkflowDefinitionHandle.DefinitionVersionId))),
+                    CorrelationId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.CorrelationId)),
+                    TriggerActivityId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.TriggerActivityId)),
+                    Input = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Input)),
+                    Variables = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Variables)),
+                    Properties = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Properties)),
+                    ParentId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.ParentId))
+                };
+
                 var startResponse = await workflowStarter.StartWorkflowAsync(startRequest, cancellationToken);
 
                 if (startResponse.CannotStart)
@@ -53,29 +55,29 @@ public class RunWorkflowJob(
 
                 logger.LogInformation("Started workflow {WorkflowInstanceId} with correlation ID {CorrelationId}", startResponse.WorkflowInstanceId, startRequest.CorrelationId);
             }
-            catch (WorkflowGraphNotFoundException e)
-            {
-                logger.LogWarning(e, "Could not find workflow graph for workflow definition handle {WorkflowDefinitionHandle}", startRequest.WorkflowDefinitionHandle);
-                await context.Scheduler.UnscheduleJob(context.Trigger.Key, cancellationToken);
-            }
-            catch (Exception e) when (retryScheduler.IsRetryable(e))
-            {
-                if (await retryScheduler.TryScheduleRetryAsync(context, e, cancellationToken))
-                    return;
+        }
+        catch (WorkflowGraphNotFoundException e)
+        {
+            logger.LogWarning(e, "Could not find workflow graph for workflow definition handle {WorkflowDefinitionHandle}", startRequest?.WorkflowDefinitionHandle);
+            await context.Scheduler.UnscheduleJob(context.Trigger.Key, cancellationToken);
+        }
+        catch (Exception e) when (retryScheduler.IsRetryable(e))
+        {
+            if (await retryScheduler.TryScheduleRetryAsync(context, e, cancellationToken))
+                return;
 
-                logger.LogError(
-                    e,
-                    "Retries are exhausted for job {JobKey} after {RetryAttempts} retry attempt(s). Giving up on starting workflow {WorkflowDefinitionHandle} with correlation ID {CorrelationId}",
-                    context.JobDetail.Key,
-                    context.GetRetryAttempt(),
-                    startRequest.WorkflowDefinitionHandle,
-                    startRequest.CorrelationId);
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "An error occurred while starting workflow {WorkflowDefinitionHandle} with correlation ID {CorrelationId}", startRequest.WorkflowDefinitionHandle, startRequest.CorrelationId);
-                await context.DeleteJob(context.JobDetail.Key, cancellationToken);
-            }
+            logger.LogError(
+                e,
+                "No retry was scheduled for job {JobKey} after {RetryAttempts} retry attempt(s) (retries disabled, exhausted, or trigger no longer present). Giving up on starting workflow {WorkflowDefinitionHandle} with correlation ID {CorrelationId}",
+                context.JobDetail.Key,
+                context.GetRetryAttempt(),
+                startRequest?.WorkflowDefinitionHandle,
+                startRequest?.CorrelationId);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "An error occurred while starting workflow {WorkflowDefinitionHandle} with correlation ID {CorrelationId}", startRequest?.WorkflowDefinitionHandle, startRequest?.CorrelationId);
+            await context.DeleteJob(context.JobDetail.Key, cancellationToken);
         }
     }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/RunWorkflowJob.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/RunWorkflowJob.cs
@@ -1,6 +1,5 @@
 using Elsa.Common.Multitenancy;
 using Elsa.Extensions;
-using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime;
@@ -19,7 +18,6 @@ public class RunWorkflowJob(
     ITenantAccessor tenantAccessor,
     ITenantFinder tenantFinder,
     IWorkflowStarter workflowStarter,
-    ITransientExceptionDetector transientExceptionDetector,
     IQuartzJobRetryScheduler retryScheduler,
     ILogger<RunWorkflowJob> logger) : IJob
 {
@@ -60,10 +58,19 @@ public class RunWorkflowJob(
                 logger.LogWarning(e, "Could not find workflow graph for workflow definition handle {WorkflowDefinitionHandle}", startRequest.WorkflowDefinitionHandle);
                 await context.Scheduler.UnscheduleJob(context.Trigger.Key, cancellationToken);
             }
-            catch (Exception e) when (transientExceptionDetector.IsTransient(e))
+            catch (Exception e) when (retryScheduler.IsRetryable(e))
             {
-                logger.LogWarning(e, "A transient error occurred while starting workflow {WorkflowDefinitionHandle} with correlation ID {CorrelationId}. Rescheduling job for retry", startRequest.WorkflowDefinitionHandle, startRequest.CorrelationId);
-                await retryScheduler.ScheduleRetryAsync(context, cancellationToken);
+                // The retry scheduler logs the scheduled retry, including the attempt number and delay.
+                if (await retryScheduler.ScheduleRetryAsync(context, e, cancellationToken))
+                    return;
+
+                logger.LogError(
+                    e,
+                    "Retries are exhausted for job {JobKey} after {RetryAttempts} retry attempt(s). Giving up on starting workflow {WorkflowDefinitionHandle} with correlation ID {CorrelationId}",
+                    context.JobDetail.Key,
+                    context.GetRetryAttempt(),
+                    startRequest.WorkflowDefinitionHandle,
+                    startRequest.CorrelationId);
             }
             catch (Exception e)
             {

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/RunWorkflowJob.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Jobs/RunWorkflowJob.cs
@@ -60,8 +60,7 @@ public class RunWorkflowJob(
             }
             catch (Exception e) when (retryScheduler.IsRetryable(e))
             {
-                // The retry scheduler logs the scheduled retry, including the attempt number and delay.
-                if (await retryScheduler.ScheduleRetryAsync(context, e, cancellationToken))
+                if (await retryScheduler.TryScheduleRetryAsync(context, e, cancellationToken))
                     return;
 
                 logger.LogError(

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Models/QuartzJobRetryContext.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Models/QuartzJobRetryContext.cs
@@ -1,0 +1,42 @@
+using Quartz;
+
+namespace Elsa.Scheduling.Quartz.Models;
+
+/// <summary>
+/// Describes a single retry of a failed Quartz job. Passed to a custom delay generator so that applications can
+/// override the delay computed by the configured backoff policy.
+/// </summary>
+public class QuartzJobRetryContext
+{
+    /// <summary>
+    /// The execution context of the attempt that just failed.
+    /// </summary>
+    public required IJobExecutionContext JobExecutionContext { get; init; }
+
+    /// <summary>
+    /// The exception that caused the job to fail.
+    /// </summary>
+    public required Exception Exception { get; init; }
+
+    /// <summary>
+    /// The one-based number of the retry that is about to be scheduled. The first retry after the initial failure is
+    /// attempt 1.
+    /// </summary>
+    public required int AttemptNumber { get; init; }
+
+    /// <summary>
+    /// The maximum number of retries that will be scheduled, as configured by <c>QuartzJobOptions.MaxRetryAttempts</c>.
+    /// </summary>
+    public required int MaxRetryAttempts { get; init; }
+
+    /// <summary>
+    /// The delay computed by the configured backoff policy. A custom delay generator can return this value to keep the
+    /// computed delay, or <c>null</c> to fall back to it.
+    /// </summary>
+    public required TimeSpan ComputedDelay { get; init; }
+
+    /// <summary>
+    /// The key of the job that failed.
+    /// </summary>
+    public JobKey JobKey => JobExecutionContext.JobDetail.Key;
+}

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Models/QuartzJobRetryContext.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Models/QuartzJobRetryContext.cs
@@ -1,3 +1,4 @@
+using Elsa.Scheduling.Quartz.Options;
 using Quartz;
 
 namespace Elsa.Scheduling.Quartz.Models;
@@ -25,7 +26,7 @@ public class QuartzJobRetryContext
     public required int AttemptNumber { get; init; }
 
     /// <summary>
-    /// The maximum number of retries that will be scheduled, as configured by <c>QuartzJobOptions.MaxRetryAttempts</c>.
+    /// The maximum number of retries that will be scheduled, as configured by <see cref="QuartzJobOptions.MaxRetryAttempts"/>.
     /// </summary>
     public required int MaxRetryAttempts { get; init; }
 

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/QuartzJobOptions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/QuartzJobOptions.cs
@@ -17,8 +17,14 @@ public class QuartzJobOptions
 
     /// <summary>
     /// The maximum number of retries scheduled for a single failing job. Defaults to <c>5</c>. Once this number of
-    /// retries has been made, the job is abandoned. A value of <c>0</c> disables retries.
+    /// retries has been made, the job is abandoned. A value of zero or less disables retries.
     /// </summary>
+    /// <remarks>
+    /// Before this change, failed jobs retried indefinitely with a fixed 10-second delay. Now, retries stop after
+    /// <see cref="MaxRetryAttempts"/> attempts (5 by default, roughly 15 seconds of exponential backoff). Deployments
+    /// that relied on retrying through longer outages should raise <see cref="MaxRetryAttempts"/> and/or
+    /// <see cref="MaxRetryDelay"/> when upgrading.
+    /// </remarks>
     public int MaxRetryAttempts { get; set; } = 5;
 
     /// <summary>

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/QuartzJobOptions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/QuartzJobOptions.cs
@@ -1,12 +1,76 @@
+using Elsa.Scheduling.Quartz.Models;
+
 namespace Elsa.Scheduling.Quartz.Options;
 
 /// <summary>
-/// Options for Quartz job execution behavior.
+/// Options for Quartz job execution behavior, including the retry policy applied to jobs that fail with a retryable
+/// exception. Every retry is scheduled as a new Quartz trigger, so retries survive an application restart and never
+/// occupy a Quartz worker thread while waiting.
 /// </summary>
 public class QuartzJobOptions
 {
     /// <summary>
-    /// The delay in seconds before rescheduling a job after a transient failure.
+    /// Whether failed jobs are retried at all. Defaults to <c>true</c>. When <c>false</c>, a failed job is logged and
+    /// abandoned instead of being rescheduled.
     /// </summary>
-    public TimeSpan TransientExceptionRetryDelay { get; set; } = TimeSpan.FromSeconds(10);
+    public bool RetryEnabled { get; set; } = true;
+
+    /// <summary>
+    /// The maximum number of retries scheduled for a single failing job. Defaults to <c>5</c>. Once this number of
+    /// retries has been made, the job is abandoned. A value of <c>0</c> disables retries.
+    /// </summary>
+    public int MaxRetryAttempts { get; set; } = 5;
+
+    /// <summary>
+    /// The delay before the first retry, and the base value the backoff strategy multiplies. Defaults to 500
+    /// milliseconds. A value of zero or less makes every retry fire immediately.
+    /// </summary>
+    public TimeSpan InitialRetryDelay { get; set; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// The upper bound of the computed retry delay. Defaults to one minute. A value of zero or less removes the cap.
+    /// </summary>
+    public TimeSpan MaxRetryDelay { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// The backoff strategy used to grow the delay between retries. Defaults to
+    /// <see cref="RetryBackoffType.Exponential"/>.
+    /// </summary>
+    public RetryBackoffType BackoffType { get; set; } = RetryBackoffType.Exponential;
+
+    /// <summary>
+    /// Whether to apply jitter to the computed delay, spreading retries of jobs that failed at the same time. Defaults
+    /// to <c>true</c>. Jitter multiplies the computed delay by a uniformly random factor between 0.8 and 1.2, before
+    /// <see cref="MaxRetryDelay"/> is applied.
+    /// </summary>
+    public bool UseJitter { get; set; } = true;
+
+    /// <summary>
+    /// An optional delegate that overrides the computed retry delay. Return <c>null</c> to fall back to the delay
+    /// computed from <see cref="BackoffType"/>, <see cref="InitialRetryDelay"/>, <see cref="MaxRetryDelay"/> and
+    /// <see cref="UseJitter"/>. Defaults to <c>null</c>, meaning the computed delay is used. A negative delay is
+    /// treated as zero.
+    /// </summary>
+    public Func<QuartzJobRetryContext, TimeSpan?>? DelayGenerator { get; set; }
+
+    /// <summary>
+    /// An optional delegate that decides whether an exception is worth retrying. When set, it fully replaces the
+    /// <see cref="Elsa.Resilience.ITransientExceptionDetector"/>: exceptions for which it returns <c>false</c> are
+    /// treated as permanent failures. Defaults to <c>null</c>, meaning the transient exception detector decides.
+    /// </summary>
+    public Func<Exception, bool>? IsRetryable { get; set; }
+
+    /// <summary>
+    /// The delay before rescheduling a job after a transient failure.
+    /// </summary>
+    /// <remarks>
+    /// Reads and writes <see cref="InitialRetryDelay"/>, so existing configuration keeps working. Note that the delay
+    /// is now the starting point of the configured backoff strategy rather than a fixed delay.
+    /// </remarks>
+    [Obsolete("Use InitialRetryDelay instead. This property gets and sets the same value.")]
+    public TimeSpan TransientExceptionRetryDelay
+    {
+        get => InitialRetryDelay;
+        set => InitialRetryDelay = value;
+    }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/QuartzJobOptions.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/QuartzJobOptions.cs
@@ -4,8 +4,9 @@ namespace Elsa.Scheduling.Quartz.Options;
 
 /// <summary>
 /// Options for Quartz job execution behavior, including the retry policy applied to jobs that fail with a retryable
-/// exception. Every retry is scheduled as a new Quartz trigger, so retries survive an application restart and never
-/// occupy a Quartz worker thread while waiting.
+/// exception. Every retry is scheduled as a new Quartz trigger, so a pending retry never occupies a Quartz worker
+/// thread while waiting, and it survives an application restart when Quartz is configured with a persistent job
+/// store (with the default in-memory store, pending retries are lost on restart).
 /// </summary>
 public class QuartzJobOptions
 {

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/RetryBackoffType.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Options/RetryBackoffType.cs
@@ -1,0 +1,22 @@
+namespace Elsa.Scheduling.Quartz.Options;
+
+/// <summary>
+/// The backoff strategy used to compute the delay between two retries of a failed Quartz job.
+/// </summary>
+public enum RetryBackoffType
+{
+    /// <summary>
+    /// The delay doubles with every attempt: <c>InitialRetryDelay * 2^(attempt - 1)</c>. This is the default.
+    /// </summary>
+    Exponential = 0,
+
+    /// <summary>
+    /// The delay grows linearly with every attempt: <c>InitialRetryDelay * attempt</c>.
+    /// </summary>
+    Linear = 1,
+
+    /// <summary>
+    /// The delay is the same for every attempt: <c>InitialRetryDelay</c>.
+    /// </summary>
+    Constant = 2
+}

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzJobRetryScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzJobRetryScheduler.cs
@@ -41,11 +41,12 @@ public class QuartzJobRetryScheduler(
             return false;
         }
 
-        var attemptNumber = context.GetRetryAttempt() + 1;
+        var attemptsMade = Math.Max(context.GetRetryAttempt(), 0);
 
-        if (attemptNumber > jobOptions.MaxRetryAttempts)
+        if (attemptsMade >= jobOptions.MaxRetryAttempts)
             return false;
 
+        var attemptNumber = attemptsMade + 1;
         var delay = GetDelay(context, exception, attemptNumber, jobOptions);
         var retryTrigger = CreateRetryTrigger(context, attemptNumber, delay);
 
@@ -57,7 +58,14 @@ public class QuartzJobRetryScheduler(
             jobOptions.MaxRetryAttempts,
             delay);
 
-        await context.Scheduler.RescheduleJob(context.Trigger.Key, retryTrigger, cancellationToken);
+        var scheduledStartTime = await context.Scheduler.RescheduleJob(context.Trigger.Key, retryTrigger, cancellationToken);
+
+        if (scheduledStartTime == null)
+        {
+            logger.LogWarning("Trigger {TriggerKey} for job {JobKey} was no longer present. No retry was scheduled", context.Trigger.Key, jobKey);
+            return false;
+        }
+
         return true;
     }
 
@@ -98,11 +106,14 @@ public class QuartzJobRetryScheduler(
 
         jobDataMap[QuartzJobDataKeys.RetryAttempt] = attemptNumber.ToString(CultureInfo.InvariantCulture);
 
+        var now = systemClock.UtcNow;
+        var startAt = delay >= DateTimeOffset.MaxValue - now ? DateTimeOffset.MaxValue : now.Add(delay);
+
         return TriggerBuilder.Create()
             .ForJob(context.JobDetail.Key)
             .WithIdentity(context.Trigger.Key)
             .UsingJobData(jobDataMap)
-            .StartAt(systemClock.UtcNow.Add(delay))
+            .StartAt(startAt)
             .Build();
     }
 }

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzJobRetryScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzJobRetryScheduler.cs
@@ -1,28 +1,108 @@
+using System.Globalization;
 using Elsa.Common;
+using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.Contracts;
+using Elsa.Scheduling.Quartz.Models;
 using Elsa.Scheduling.Quartz.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Quartz;
 
 namespace Elsa.Scheduling.Quartz.Services;
 
 /// <summary>
-/// Default implementation of <see cref="IQuartzJobRetryScheduler"/>.
+/// Default implementation of <see cref="IQuartzJobRetryScheduler"/>. Rather than retrying in-process, each retry is
+/// scheduled as a new Quartz trigger, so that a pending retry survives an application restart and does not occupy a
+/// Quartz worker thread while waiting.
 /// </summary>
-public class QuartzJobRetryScheduler(ISystemClock systemClock, IOptions<QuartzJobOptions> options) : IQuartzJobRetryScheduler
+public class QuartzJobRetryScheduler(
+    ISystemClock systemClock,
+    IOptions<QuartzJobOptions> options,
+    IQuartzRetryDelayCalculator delayCalculator,
+    ITransientExceptionDetector transientExceptionDetector,
+    ILogger<QuartzJobRetryScheduler> logger) : IQuartzJobRetryScheduler
 {
     /// <inheritdoc />
-    public async Task ScheduleRetryAsync(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    public bool IsRetryable(Exception exception)
     {
-        var delay = options.Value.TransientExceptionRetryDelay;
-        var now = systemClock.UtcNow;
+        var isRetryable = options.Value.IsRetryable;
+        return isRetryable != null ? isRetryable(exception) : transientExceptionDetector.IsTransient(exception);
+    }
 
-        var trigger = TriggerBuilder.Create()
+    /// <inheritdoc />
+    public async Task<bool> ScheduleRetryAsync(IJobExecutionContext context, Exception exception, CancellationToken cancellationToken = default)
+    {
+        var jobOptions = options.Value;
+        var jobKey = context.JobDetail.Key;
+
+        if (!jobOptions.RetryEnabled)
+        {
+            logger.LogDebug("Retries are disabled. Not rescheduling job {JobKey}", jobKey);
+            return false;
+        }
+
+        var attemptNumber = context.GetRetryAttempt() + 1;
+
+        if (attemptNumber > jobOptions.MaxRetryAttempts)
+            return false;
+
+        var delay = GetDelay(context, exception, attemptNumber, jobOptions);
+        var retryTrigger = CreateRetryTrigger(context, attemptNumber, delay);
+
+        logger.LogWarning(
+            exception,
+            "Job {JobKey} failed with a retryable error. Scheduling retry {AttemptNumber} of {MaxRetryAttempts} in {RetryDelay}",
+            jobKey,
+            attemptNumber,
+            jobOptions.MaxRetryAttempts,
+            delay);
+
+        await context.Scheduler.RescheduleJob(context.Trigger.Key, retryTrigger, cancellationToken);
+        return true;
+    }
+
+    private TimeSpan GetDelay(IJobExecutionContext context, Exception exception, int attemptNumber, QuartzJobOptions jobOptions)
+    {
+        var computedDelay = delayCalculator.CalculateDelay(attemptNumber, jobOptions);
+        var delayGenerator = jobOptions.DelayGenerator;
+
+        if (delayGenerator == null)
+            return computedDelay;
+
+        var retryContext = new QuartzJobRetryContext
+        {
+            JobExecutionContext = context,
+            Exception = exception,
+            AttemptNumber = attemptNumber,
+            MaxRetryAttempts = jobOptions.MaxRetryAttempts,
+            ComputedDelay = computedDelay
+        };
+
+        var customDelay = delayGenerator(retryContext);
+
+        if (customDelay == null)
+            return computedDelay;
+
+        return customDelay.Value > TimeSpan.Zero ? customDelay.Value : TimeSpan.Zero;
+    }
+
+    private ITrigger CreateRetryTrigger(IJobExecutionContext context, int attemptNumber, TimeSpan delay)
+    {
+        // Carry over the job data of the failed trigger so that the workflow inputs it carries are not lost, and keep
+        // the original trigger key so that the retry remains addressable (for example, to unschedule it).
+        var jobDataMap = new JobDataMap();
+        var triggerJobDataMap = context.Trigger.JobDataMap;
+
+        if (triggerJobDataMap != null)
+            jobDataMap.PutAll(triggerJobDataMap);
+
+        jobDataMap[QuartzJobDataKeys.RetryAttempt] = attemptNumber.ToString(CultureInfo.InvariantCulture);
+
+        return TriggerBuilder.Create()
             .ForJob(context.JobDetail.Key)
-            .StartAt(now.Add(delay))
+            .WithIdentity(context.Trigger.Key)
+            .UsingJobData(jobDataMap)
+            .StartAt(systemClock.UtcNow.Add(delay))
             .Build();
-
-        await context.Scheduler.RescheduleJob(context.Trigger.Key, trigger, cancellationToken);
     }
 }
-

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzJobRetryScheduler.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzJobRetryScheduler.cs
@@ -12,8 +12,9 @@ namespace Elsa.Scheduling.Quartz.Services;
 
 /// <summary>
 /// Default implementation of <see cref="IQuartzJobRetryScheduler"/>. Rather than retrying in-process, each retry is
-/// scheduled as a new Quartz trigger, so that a pending retry survives an application restart and does not occupy a
-/// Quartz worker thread while waiting.
+/// scheduled as a new Quartz trigger, so that a pending retry does not occupy a Quartz worker thread while waiting,
+/// and it survives an application restart when Quartz is configured with a persistent job store (with the default
+/// in-memory store, pending retries are lost on restart).
 /// </summary>
 public class QuartzJobRetryScheduler(
     ISystemClock systemClock,

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzRetryDelayCalculator.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/Services/QuartzRetryDelayCalculator.cs
@@ -1,0 +1,57 @@
+using Elsa.Scheduling.Quartz.Contracts;
+using Elsa.Scheduling.Quartz.Options;
+
+namespace Elsa.Scheduling.Quartz.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IQuartzRetryDelayCalculator"/>. Computes a backoff delay with optional jitter,
+/// following the same semantics as Polly's retry strategies, but without pinning a thread while waiting.
+/// </summary>
+/// <param name="random">
+/// The random source used to compute jitter. Defaults to <see cref="System.Random.Shared"/>, which is thread-safe.
+/// Pass a seeded instance to make jitter deterministic in tests; such an instance must not be shared across threads.
+/// </param>
+public class QuartzRetryDelayCalculator(Random? random = null) : IQuartzRetryDelayCalculator
+{
+    /// <summary>
+    /// The lowest factor jitter can multiply the computed delay by.
+    /// </summary>
+    public const double MinJitterFactor = 0.8;
+
+    /// <summary>
+    /// The highest factor jitter can multiply the computed delay by.
+    /// </summary>
+    public const double MaxJitterFactor = 1.2;
+
+    private readonly Random _random = random ?? Random.Shared;
+
+    /// <inheritdoc />
+    public TimeSpan CalculateDelay(int attemptNumber, QuartzJobOptions options)
+    {
+        var attempt = Math.Max(1, attemptNumber);
+        double initialTicks = options.InitialRetryDelay.Ticks;
+
+        if (initialTicks <= 0)
+            return TimeSpan.Zero;
+
+        var multiplier = options.BackoffType switch
+        {
+            RetryBackoffType.Linear => attempt,
+            RetryBackoffType.Constant => 1d,
+            _ => Math.Pow(2, attempt - 1)
+        };
+
+        var ticks = initialTicks * multiplier;
+
+        if (options.UseJitter)
+            ticks *= MinJitterFactor + _random.NextDouble() * (MaxJitterFactor - MinJitterFactor);
+
+        // A non-positive maximum removes the cap; the delay is then bounded only by TimeSpan itself.
+        double maxTicks = options.MaxRetryDelay.Ticks;
+
+        if (maxTicks > 0 && ticks >= maxTicks)
+            return options.MaxRetryDelay;
+
+        return ticks >= long.MaxValue ? TimeSpan.MaxValue : TimeSpan.FromTicks((long)ticks);
+    }
+}

--- a/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzSchedulerFeature.cs
+++ b/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzSchedulerFeature.cs
@@ -31,6 +31,7 @@ public class QuartzSchedulerFeature : IShellFeature
         services
             .AddSingleton<IActivityDescriptorModifier, CronActivityDescriptorModifier>()
             .AddScoped<IJobKeyProvider, JobKeyProvider>()
+            .AddSingleton<IQuartzRetryDelayCalculator, QuartzRetryDelayCalculator>()
             .AddSingleton<IQuartzJobRetryScheduler, QuartzJobRetryScheduler>()
             .AddStartupTask<RegisterJobsTask>()
             .AddScoped<IWorkflowScheduler, QuartzWorkflowScheduler>()

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.ComponentTests/Fixtures/WorkflowServer.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.ComponentTests/Fixtures/WorkflowServer.cs
@@ -32,7 +32,7 @@ public class WorkflowServer(string url) : WebApplicationFactory<Program>
         builder.ConfigureTestServices(services =>
         {
             // Configure Quartz job options for fast retries in tests
-            services.Configure<QuartzJobOptions>(options => options.TransientExceptionRetryDelay = TimeSpan.FromSeconds(1));
+            services.Configure<QuartzJobOptions>(options => options.InitialRetryDelay = TimeSpan.FromSeconds(1));
         });
     }
 }

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.ComponentTests/Helpers/FailingWorkflowStarter.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.ComponentTests/Helpers/FailingWorkflowStarter.cs
@@ -11,6 +11,13 @@ public class FailingWorkflowStarter(IWorkflowStarter innerStarter) : IWorkflowSt
 
     public int FailuresBeforeSuccess { get; set; }
     public Exception? ExceptionToThrow { get; set; }
+
+    /// <summary>
+    /// The response to return once the configured number of failures has been exhausted. When not set, the call is
+    /// forwarded to the inner starter.
+    /// </summary>
+    public StartWorkflowResponse? SuccessResponse { get; set; }
+
     public int CallCount => _callCount;
 
     public async Task<StartWorkflowResponse> StartWorkflowAsync(StartWorkflowRequest request, CancellationToken cancellationToken = default)
@@ -21,6 +28,9 @@ public class FailingWorkflowStarter(IWorkflowStarter innerStarter) : IWorkflowSt
         {
             throw ExceptionToThrow;
         }
+
+        if (SuccessResponse != null)
+            return SuccessResponse;
 
         return await innerStarter.StartWorkflowAsync(request, cancellationToken);
     }

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.ComponentTests/QuartzJobTransientRetryTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.ComponentTests/QuartzJobTransientRetryTests.cs
@@ -1,21 +1,31 @@
+using Elsa.Common;
+using Elsa.Common.Multitenancy;
 using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.ComponentTests.Abstractions;
 using Elsa.Scheduling.Quartz.ComponentTests.Fixtures;
 using Elsa.Scheduling.Quartz.ComponentTests.Helpers;
 using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Scheduling.Quartz.Jobs;
+using Elsa.Scheduling.Quartz.Options;
+using Elsa.Scheduling.Quartz.Services;
 using Elsa.Workflows.Runtime;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Quartz;
+using QuartzScheduler = Quartz.IScheduler;
 
 namespace Elsa.Scheduling.Quartz.ComponentTests;
 
 /// <summary>
 /// Component tests for Quartz job transient retry behavior.
-/// These tests validate that jobs properly retry on transient exceptions and give up on non-transient exceptions.
+/// These tests validate that jobs properly retry on transient exceptions, count their attempts across reschedules,
+/// stop once the configured maximum is reached, and give up immediately on non-transient exceptions.
 /// </summary>
 public class QuartzJobTransientRetryTests(SchedulingApp app) : AppComponentTest(app)
 {
+    private const string DefinitionVersionIdKey = "DefinitionVersionId";
+    private const string DefinitionVersionId = "test-workflow-def";
+
     [Theory]
     [InlineData(2, typeof(TimeoutException), "Simulated transient timeout")]
     [InlineData(1, typeof(HttpRequestException), "Simulated network error")]
@@ -24,155 +34,217 @@ public class QuartzJobTransientRetryTests(SchedulingApp app) : AppComponentTest(
         Type exceptionType,
         string exceptionMessage)
     {
-        // Arrange - Create job manually with test double for controlled testing
-        var (job, failingStarter, context) = await CreateTestJobSetupWithoutScheduling(
+        var scenario = await CreateScenarioAsync(
+            $"test-transient-{failuresBeforeSuccess}",
             failuresBeforeSuccess,
-            (Exception)Activator.CreateInstance(exceptionType, exceptionMessage)!,
-            $"test-transient-{failuresBeforeSuccess}"
-        );
+            (Exception)Activator.CreateInstance(exceptionType, exceptionMessage)!);
 
-        // Act - Execute the job multiple times to simulate retries
-        for (var i = 0; i < failuresBeforeSuccess; i++)
+        // Every failing execution schedules the next retry and counts it on the rescheduled trigger.
+        for (var attempt = 1; attempt <= failuresBeforeSuccess; attempt++)
         {
-            await job.Execute(context);
-            Assert.Equal(i + 1, failingStarter.CallCount);
+            await scenario.ExecuteAsync();
+
+            Assert.Equal(attempt, scenario.Starter.CallCount);
+            Assert.Equal(attempt, await scenario.GetRetryAttemptAsync());
+
+            // The workflow inputs carried by the original trigger must survive the reschedule.
+            Assert.Equal(DefinitionVersionId, (await scenario.GetTriggerAsync())!.JobDataMap.GetString(DefinitionVersionIdKey));
         }
 
-        // Final attempt - should succeed
-        await job.Execute(context);
+        // The next execution succeeds, so no further retry is scheduled and the attempt count stops growing.
+        await scenario.ExecuteAsync();
 
-        // Assert
-        Assert.Equal(failuresBeforeSuccess + 1, failingStarter.CallCount);
+        Assert.Equal(failuresBeforeSuccess + 1, scenario.Starter.CallCount);
+        Assert.Equal(failuresBeforeSuccess, await scenario.GetRetryAttemptAsync());
+    }
+
+    [Fact]
+    public async Task RunWorkflowJob_TransientException_StopsAfterMaxRetryAttempts()
+    {
+        const int maxRetryAttempts = 2;
+        var scenario = await CreateScenarioAsync(
+            "test-exhaustion",
+            failuresBeforeSuccess: int.MaxValue,
+            new TimeoutException("Simulated permanent outage"),
+            options => options.MaxRetryAttempts = maxRetryAttempts);
+
+        for (var attempt = 1; attempt <= maxRetryAttempts; attempt++)
+        {
+            await scenario.ExecuteAsync();
+            Assert.Equal(attempt, await scenario.GetRetryAttemptAsync());
+        }
+
+        // The retry budget is now exhausted: the job runs once more, but is not rescheduled again.
+        await scenario.ExecuteAsync();
+
+        Assert.Equal(maxRetryAttempts + 1, scenario.Starter.CallCount);
+        Assert.Equal(maxRetryAttempts, await scenario.GetRetryAttemptAsync());
+
+        // Exhausting the retries must not delete the job: that is reserved for non-transient failures.
+        Assert.True(await scenario.Scheduler.CheckExists(scenario.Context.JobDetail.Key));
+    }
+
+    [Fact]
+    public async Task RunWorkflowJob_RetriesDisabled_DoesNotReschedule()
+    {
+        var scenario = await CreateScenarioAsync(
+            "test-retries-disabled",
+            failuresBeforeSuccess: int.MaxValue,
+            new TimeoutException("Simulated transient timeout"),
+            options => options.RetryEnabled = false);
+
+        await scenario.ExecuteAsync();
+
+        Assert.Equal(1, scenario.Starter.CallCount);
+        Assert.Equal(0, await scenario.GetRetryAttemptAsync());
+        Assert.True(await scenario.Scheduler.CheckExists(scenario.Context.JobDetail.Key));
     }
 
     [Fact]
     public async Task RunWorkflowJob_NonTransientException_DoesNotRetry()
     {
-        // Arrange - Schedule job with Quartz so we can verify it gets deleted
-        var (job, failingStarter, context) = await CreateTestJobSetupWithScheduling(
-            10, // Would retry many times if transient
-            new InvalidOperationException("Non-transient error"),
-            "test-nontransient"
-        );
+        var scenario = await CreateScenarioAsync(
+            "test-nontransient",
+            failuresBeforeSuccess: int.MaxValue,
+            new InvalidOperationException("Non-transient error"));
 
-        var scheduler = await WorkflowServer.GetSchedulerAsync();
-
-        // Act
-        await job.Execute(context);
+        await scenario.ExecuteAsync();
 
         // Assert - Job should be called once, then deleted (not retried)
-        Assert.Equal(1, failingStarter.CallCount);
-
-        // Verify job was deleted from scheduler
-        var jobExists = await scheduler.CheckExists(context.JobDetail.Key);
-        Assert.False(jobExists);
+        Assert.Equal(1, scenario.Starter.CallCount);
+        Assert.Equal(0, await scenario.GetRetryAttemptAsync());
+        Assert.False(await scenario.Scheduler.CheckExists(scenario.Context.JobDetail.Key));
     }
 
     /// <summary>
-    /// Creates a test setup without scheduling the job with Quartz.
-    /// Use when testing job execution logic directly without needing scheduler interaction.
+    /// Schedules a durable job with a trigger that carries the workflow payload, and wires a <see cref="RunWorkflowJob"/>
+    /// around a workflow starter that fails the requested number of times. The trigger is scheduled far enough in the
+    /// future for Quartz not to fire it on its own: the test drives execution explicitly.
     /// </summary>
-    private async Task<(RunWorkflowJob job, FailingWorkflowStarter failingStarter, IJobExecutionContext context)>
-        CreateTestJobSetupWithoutScheduling(int failuresBeforeSuccess, Exception exception, string jobIdentifier)
+    private async Task<RetryScenario> CreateScenarioAsync(
+        string identifier,
+        int failuresBeforeSuccess,
+        Exception exception,
+        Action<QuartzJobOptions>? configureOptions = null)
     {
         var scheduler = await WorkflowServer.GetSchedulerAsync();
-        var workflowStarter = Scope.ServiceProvider.GetRequiredService<IWorkflowStarter>();
 
-        var failingStarter = new FailingWorkflowStarter(workflowStarter)
+        var starter = new FailingWorkflowStarter(Scope.ServiceProvider.GetRequiredService<IWorkflowStarter>())
         {
             FailuresBeforeSuccess = failuresBeforeSuccess,
-            ExceptionToThrow = exception
-        };
-
-        var job = CreateRunWorkflowJob(failingStarter);
-        var (jobDetail, trigger) = CreateJobDetailAndTrigger(jobIdentifier);
-        
-        // Don't schedule with Quartz - we're testing the Execute method directly
-        var context = CreateTestContext(scheduler, jobDetail, trigger);
-
-        return (job, failingStarter, context);
-    }
-
-    /// <summary>
-    /// Creates a test setup and schedules the job with Quartz.
-    /// Use when testing behavior that involves scheduler operations (e.g., job deletion).
-    /// </summary>
-    private async Task<(RunWorkflowJob job, FailingWorkflowStarter failingStarter, IJobExecutionContext context)>
-        CreateTestJobSetupWithScheduling(int failuresBeforeSuccess, Exception exception, string jobIdentifier)
-    {
-        var scheduler = await WorkflowServer.GetSchedulerAsync();
-        var workflowStarter = Scope.ServiceProvider.GetRequiredService<IWorkflowStarter>();
-
-        var failingStarter = new FailingWorkflowStarter(workflowStarter)
-        {
-            FailuresBeforeSuccess = failuresBeforeSuccess,
-            ExceptionToThrow = exception
-        };
-
-        var job = CreateRunWorkflowJob(failingStarter);
-        var (jobDetail, trigger) = CreateJobDetailAndTrigger(jobIdentifier);
-
-        // Schedule the job with Quartz so the job can interact with the scheduler
-        // (e.g., delete itself on non-transient exceptions)
-        await scheduler.ScheduleJob(jobDetail, trigger);
-        var context = CreateTestContext(scheduler, jobDetail, trigger);
-
-        return (job, failingStarter, context);
-    }
-
-    private RunWorkflowJob CreateRunWorkflowJob(IWorkflowStarter workflowStarter)
-    {
-        return new RunWorkflowJob(
-            Scope.ServiceProvider.GetRequiredService<Common.Multitenancy.ITenantAccessor>(),
-            Scope.ServiceProvider.GetRequiredService<Common.Multitenancy.ITenantFinder>(),
-            workflowStarter,
-            Scope.ServiceProvider.GetRequiredService<ITransientExceptionDetector>(),
-            Scope.ServiceProvider.GetRequiredService<IQuartzJobRetryScheduler>(),
-            Scope.ServiceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<RunWorkflowJob>>()
-        );
-    }
-
-    private static (IJobDetail jobDetail, ITrigger trigger) CreateJobDetailAndTrigger(string identifier)
-    {
-        var jobDataMap = new JobDataMap
-        {
-            { "DefinitionVersionId", "test-workflow-def" }
+            ExceptionToThrow = exception,
+            SuccessResponse = new() { WorkflowInstanceId = $"{identifier}-instance" }
         };
 
         var jobDetail = JobBuilder.Create<RunWorkflowJob>()
             .WithIdentity($"{identifier}-job", "test-group")
-            .UsingJobData(jobDataMap)
             .StoreDurably()
             .Build();
 
         var trigger = TriggerBuilder.Create()
             .WithIdentity($"{identifier}-trigger", "test-group")
             .ForJob(jobDetail)
-            .StartNow()
+            .UsingJobData(DefinitionVersionIdKey, DefinitionVersionId)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
             .Build();
 
-        return (jobDetail, trigger);
+        await scheduler.ScheduleJob(jobDetail, trigger);
+
+        var job = new RunWorkflowJob(
+            Scope.ServiceProvider.GetRequiredService<ITenantAccessor>(),
+            Scope.ServiceProvider.GetRequiredService<ITenantFinder>(),
+            starter,
+            CreateRetryScheduler(configureOptions),
+            Scope.ServiceProvider.GetRequiredService<ILogger<RunWorkflowJob>>());
+
+        return new(job, starter, new(scheduler, jobDetail, trigger), scheduler);
     }
 
-    private static IJobExecutionContext CreateTestContext(global::Quartz.IScheduler scheduler, IJobDetail jobDetail, ITrigger trigger)
+    /// <summary>
+    /// Creates a retry scheduler backed by the application's services, but with test-specific retry options. Delays are
+    /// long enough that a scheduled retry never fires by itself during the test.
+    /// </summary>
+    private IQuartzJobRetryScheduler CreateRetryScheduler(Action<QuartzJobOptions>? configureOptions)
     {
-        return new TestJobExecutionContext(scheduler, jobDetail, trigger);
+        var options = new QuartzJobOptions
+        {
+            InitialRetryDelay = TimeSpan.FromSeconds(30),
+            MaxRetryDelay = TimeSpan.FromMinutes(5),
+            UseJitter = false
+        };
+
+        configureOptions?.Invoke(options);
+
+        return new QuartzJobRetryScheduler(
+            Scope.ServiceProvider.GetRequiredService<ISystemClock>(),
+            Microsoft.Extensions.Options.Options.Create(options),
+            Scope.ServiceProvider.GetRequiredService<IQuartzRetryDelayCalculator>(),
+            Scope.ServiceProvider.GetRequiredService<ITransientExceptionDetector>(),
+            Scope.ServiceProvider.GetRequiredService<ILogger<QuartzJobRetryScheduler>>());
+    }
+
+    private record RetryScenario(RunWorkflowJob Job, FailingWorkflowStarter Starter, TestJobExecutionContext Context, QuartzScheduler Scheduler)
+    {
+        /// <summary>
+        /// Executes the job and then points the execution context at whatever trigger the scheduler now holds, the way
+        /// Quartz would when it fires the rescheduled trigger.
+        /// </summary>
+        public async Task ExecuteAsync()
+        {
+            await Job.Execute(Context);
+            var trigger = await GetTriggerAsync();
+
+            if (trigger != null)
+                Context.Trigger = trigger;
+        }
+
+        public async Task<ITrigger?> GetTriggerAsync() => await Scheduler.GetTrigger(Context.Trigger.Key);
+
+        /// <summary>
+        /// Gets the retry attempt persisted on the trigger currently in the scheduler, or 0 when no retry was scheduled.
+        /// </summary>
+        public async Task<int> GetRetryAttemptAsync()
+        {
+            var trigger = await GetTriggerAsync();
+
+            if (trigger == null || !trigger.JobDataMap.TryGetString(QuartzJobDataKeys.RetryAttempt, out var attempt) || attempt == null)
+                return 0;
+
+            return int.Parse(attempt);
+        }
     }
 }
 
 /// <summary>
 /// Test implementation of IJobExecutionContext for component testing.
 /// </summary>
-internal class TestJobExecutionContext(global::Quartz.IScheduler scheduler, IJobDetail jobDetail, ITrigger trigger) : IJobExecutionContext
+internal class TestJobExecutionContext(QuartzScheduler scheduler, IJobDetail jobDetail, ITrigger trigger) : IJobExecutionContext
 {
-    public global::Quartz.IScheduler Scheduler => scheduler;
-    public ITrigger Trigger => trigger;
+    public QuartzScheduler Scheduler => scheduler;
+
+    /// <summary>
+    /// The trigger that fired this execution. Settable so that a test can replay an execution with the trigger a
+    /// previous retry produced.
+    /// </summary>
+    public ITrigger Trigger { get; set; } = trigger;
+
     public IJobDetail JobDetail => jobDetail;
     public IJob JobInstance => null!;
     public bool Recovering => false;
-    public TriggerKey RecoveringTriggerKey => trigger.Key;
+    public TriggerKey RecoveringTriggerKey => Trigger.Key;
     public int RefireCount => 0;
-    public JobDataMap MergedJobDataMap => jobDetail.JobDataMap;
+
+    public JobDataMap MergedJobDataMap
+    {
+        get
+        {
+            var map = new JobDataMap();
+            map.PutAll(jobDetail.JobDataMap);
+            map.PutAll(Trigger.JobDataMap);
+            return map;
+        }
+    }
+
     public ICalendar? Calendar => null;
     public DateTimeOffset FireTimeUtc => DateTimeOffset.UtcNow;
     public DateTimeOffset? ScheduledFireTimeUtc => DateTimeOffset.UtcNow;

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Helpers/QuartzJobTestHelper.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Helpers/QuartzJobTestHelper.cs
@@ -4,6 +4,7 @@ using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Scheduling.Quartz.Options;
 using Elsa.Workflows.Runtime;
 using Elsa.Workflows.Runtime.Messages;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Quartz;
@@ -21,9 +22,13 @@ public static class QuartzJobTestHelper
     /// </summary>
     public static (IJobExecutionContext Context, Mock<QuartzScheduler> Scheduler) CreateJobExecutionContext(
         IDictionary<string, object> jobData,
-        string? jobKeyName = null)
+        string? jobKeyName = null,
+        IDictionary<string, object>? triggerData = null)
     {
         var jobDataMap = new JobDataMap(jobData);
+        var triggerDataMap = new JobDataMap(triggerData ?? new Dictionary<string, object>());
+        var mergedDataMap = new JobDataMap(jobData);
+        mergedDataMap.PutAll(triggerDataMap);
         var jobKey = new JobKey(jobKeyName ?? "test-job");
         var triggerKey = new TriggerKey("test-trigger");
 
@@ -34,6 +39,7 @@ public static class QuartzJobTestHelper
         var trigger = new Mock<ITrigger>();
         trigger.Setup(t => t.Key).Returns(triggerKey);
         trigger.Setup(t => t.JobKey).Returns(jobKey);
+        trigger.Setup(t => t.JobDataMap).Returns(triggerDataMap);
 
         var scheduler = new Mock<QuartzScheduler>();
         scheduler.Setup(s => s.RescheduleJob(It.IsAny<TriggerKey>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
@@ -42,7 +48,7 @@ public static class QuartzJobTestHelper
             .ReturnsAsync(true);
 
         var context = new Mock<IJobExecutionContext>();
-        context.Setup(c => c.MergedJobDataMap).Returns(jobDataMap);
+        context.Setup(c => c.MergedJobDataMap).Returns(mergedDataMap);
         context.Setup(c => c.JobDetail).Returns(jobDetail.Object);
         context.Setup(c => c.Trigger).Returns(trigger.Object);
         context.Setup(c => c.Scheduler).Returns(scheduler.Object);
@@ -52,14 +58,25 @@ public static class QuartzJobTestHelper
     }
 
     /// <summary>
-    /// Creates a mock for QuartzJobOptions with the specified retry delay.
+    /// Creates <see cref="QuartzJobOptions"/> with deterministic retry settings: jitter is disabled so that computed
+    /// delays are exact.
     /// </summary>
-    public static Mock<IOptions<QuartzJobOptions>> CreateQuartzJobOptions(TimeSpan? retryDelay = null)
+    public static QuartzJobOptions CreateQuartzJobOptions(Action<QuartzJobOptions>? configure = null)
     {
-        var options = new Mock<IOptions<QuartzJobOptions>>();
-        options.Setup(o => o.Value).Returns(new QuartzJobOptions { TransientExceptionRetryDelay = retryDelay ?? TimeSpan.FromSeconds(1) });
+        var options = new QuartzJobOptions
+        {
+            InitialRetryDelay = TimeSpan.FromSeconds(1),
+            UseJitter = false
+        };
+
+        configure?.Invoke(options);
         return options;
     }
+
+    /// <summary>
+    /// Wraps the specified options so they can be injected into a service that takes <see cref="IOptions{TOptions}"/>.
+    /// </summary>
+    public static IOptions<QuartzJobOptions> AsOptions(this QuartzJobOptions options) => Microsoft.Extensions.Options.Options.Create(options);
 
     /// <summary>
     /// Creates a mock tenant accessor that allows context pushing.
@@ -156,4 +173,39 @@ public static class QuartzJobTestHelper
     /// </summary>
     public static void VerifyRunInstanceCalled(this Mock<IWorkflowClient> workflowClient) =>
         workflowClient.Verify(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+
+    extension<T>(Mock<ILogger<T>> logger)
+    {
+        /// <summary>
+        /// Verifies that the logger logged at the specified level the specified number of times.
+        /// </summary>
+        public void VerifyLogged(LogLevel level, Times times) =>
+            logger.Verify(
+                x => x.Log(
+                    level,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+                times);
+    }
+
+    extension(Mock<IQuartzJobRetryScheduler> retryScheduler)
+    {
+        /// <summary>
+        /// Sets up the retry scheduler to consider any exception retryable, and to report whether it scheduled a retry.
+        /// </summary>
+        public void SetupRetry(bool isRetryable, bool retryScheduled = true)
+        {
+            retryScheduler.Setup(x => x.IsRetryable(It.IsAny<Exception>())).Returns(isRetryable);
+            retryScheduler.Setup(x => x.ScheduleRetryAsync(It.IsAny<IJobExecutionContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(retryScheduled);
+        }
+
+        /// <summary>
+        /// Verifies that a retry was requested for the specified context exactly once.
+        /// </summary>
+        public void VerifyRetryScheduled(IJobExecutionContext context) =>
+            retryScheduler.Verify(x => x.ScheduleRetryAsync(context, It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/ResumeWorkflowJobTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/ResumeWorkflowJobTests.cs
@@ -111,6 +111,19 @@ public class ResumeWorkflowJobTests
     }
 
     [Fact]
+    public async Task Execute_TenantFinderThrowsTransientException_SchedulesRetryAndDoesNotPropagate()
+    {
+        var (context, _) = CreateJobExecutionContext(withTenantId: true);
+        _retryScheduler.SetupRetry(isRetryable: true);
+        _tenantFinder.Setup(f => f.FindByIdAsync("tenant-123", It.IsAny<CancellationToken>())).ThrowsAsync(new TimeoutException());
+
+        await _job.Execute(context);
+
+        _retryScheduler.VerifyRetryScheduled(context);
+        _workflowRuntime.Verify(r => r.CreateClientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Execute_UsesCorrectWorkflowInstanceId()
     {
         var (context, _) = CreateJobExecutionContext();
@@ -154,7 +167,7 @@ public class ResumeWorkflowJobTests
     }
 
     private static (IJobExecutionContext, Mock<QuartzScheduler>) CreateJobExecutionContext(string? activityHandle = null,
-        string? jobKeyName = null)
+        string? jobKeyName = null, bool withTenantId = false)
     {
         var jobData = new Dictionary<string, object>
         {
@@ -164,6 +177,9 @@ public class ResumeWorkflowJobTests
 
         if (activityHandle != null)
             jobData.Add("ActivityHandle", activityHandle);
+
+        if (withTenantId)
+            jobData["TenantId"] = "tenant-123";
 
         return QuartzJobTestHelper.CreateJobExecutionContext(jobData, jobKeyName);
     }

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/ResumeWorkflowJobTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/ResumeWorkflowJobTests.cs
@@ -1,6 +1,5 @@
 using Elsa.Common;
 using Elsa.Common.Multitenancy;
-using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Scheduling.Quartz.Jobs;
 using Elsa.Scheduling.Quartz.UnitTests.Helpers;
@@ -20,7 +19,6 @@ public class ResumeWorkflowJobTests
     private readonly Mock<IJsonSerializer> _jsonSerializer = new();
     private readonly Mock<ITenantFinder> _tenantFinder = new();
     private readonly Mock<ITenantAccessor> _tenantAccessor = QuartzJobTestHelper.CreateTenantAccessor();
-    private readonly Mock<ITransientExceptionDetector> _transientDetector = new();
     private readonly Mock<IQuartzJobRetryScheduler> _retryScheduler = new();
     private readonly Mock<ILogger<ResumeWorkflowJob>> _logger = new();
     private readonly ResumeWorkflowJob _job;
@@ -32,7 +30,6 @@ public class ResumeWorkflowJobTests
             _jsonSerializer.Object,
             _tenantFinder.Object,
             _tenantAccessor.Object,
-            _transientDetector.Object,
             _retryScheduler.Object,
             _logger.Object);
     }
@@ -51,17 +48,47 @@ public class ResumeWorkflowJobTests
     }
 
     [Theory]
-    [InlineData(typeof(HttpRequestException), true)]
-    [InlineData(typeof(TimeoutException), true)]
-    public async Task Execute_TransientException_ReschedulesJob(Type exceptionType, bool isTransient)
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    public async Task Execute_RetryableException_ReschedulesJob(Type exceptionType)
     {
-        var (context, _) = CreateJobExecutionContext();
-        _transientDetector.SetupIsTransient(isTransient);
+        var (context, scheduler) = CreateJobExecutionContext();
+        _retryScheduler.SetupRetry(isRetryable: true);
         _workflowRuntime.SetupCreateClientThrows((Exception)Activator.CreateInstance(exceptionType)!);
 
         await _job.Execute(context);
 
-        _retryScheduler.Verify(x => x.ScheduleRetryAsync(context, It.IsAny<CancellationToken>()), Times.Once);
+        _retryScheduler.VerifyRetryScheduled(context);
+        _logger.VerifyLogged(LogLevel.Error, Times.Never());
+        scheduler.VerifyNotDeleted();
+    }
+
+    [Fact]
+    public async Task Execute_RetriesExhausted_LogsErrorAndKeepsTheJob()
+    {
+        var (context, scheduler) = CreateJobExecutionContext();
+        _retryScheduler.SetupRetry(isRetryable: true, retryScheduled: false);
+        _workflowRuntime.SetupCreateClientThrows(new TimeoutException());
+
+        await _job.Execute(context);
+
+        _retryScheduler.VerifyRetryScheduled(context);
+        _logger.VerifyLogged(LogLevel.Error, Times.Once());
+        scheduler.VerifyNotDeleted();
+    }
+
+    [Fact]
+    public async Task Execute_IsRetryableOverrideRejectsTheException_TreatsItAsPermanent()
+    {
+        var (context, scheduler) = CreateJobExecutionContext();
+        _retryScheduler.SetupRetry(isRetryable: false);
+        _workflowRuntime.SetupCreateClientThrows(new TimeoutException());
+
+        await _job.Execute(context);
+
+        _retryScheduler.Verify(x => x.ScheduleRetryAsync(It.IsAny<IJobExecutionContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Never);
+        _logger.VerifyLogged(LogLevel.Error, Times.Once());
+        scheduler.VerifyDeleted();
     }
 
     [Theory]
@@ -72,7 +99,7 @@ public class ResumeWorkflowJobTests
     public async Task Execute_NonTransientException_DeletesJob(Type exceptionType, string? jobKeyName)
     {
         var (context, scheduler) = CreateJobExecutionContext(jobKeyName: jobKeyName);
-        _transientDetector.SetupIsTransient(false);
+        _retryScheduler.SetupRetry(isRetryable: false);
         _workflowRuntime.SetupCreateClientThrows((Exception)Activator.CreateInstance(exceptionType)!);
 
         await _job.Execute(context);

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/RunWorkflowJobTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/RunWorkflowJobTests.cs
@@ -129,6 +129,19 @@ public class RunWorkflowJobTests
     }
 
     [Fact]
+    public async Task Execute_TenantFinderThrowsTransientException_SchedulesRetryAndDoesNotPropagate()
+    {
+        var (context, _) = CreateJobExecutionContext(withTenantId: true);
+        _retryScheduler.SetupRetry(isRetryable: true);
+        _tenantFinder.Setup(f => f.FindByIdAsync("tenant-123", It.IsAny<CancellationToken>())).ThrowsAsync(new TimeoutException());
+
+        await _job.Execute(context);
+
+        _retryScheduler.VerifyRetryScheduled(context);
+        _workflowStarter.Verify(w => w.StartWorkflowAsync(It.IsAny<StartWorkflowRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Execute_UsesCorrectWorkflowDefinitionHandle()
     {
         var (context, _) = CreateJobExecutionContext();
@@ -143,11 +156,18 @@ public class RunWorkflowJobTests
         Assert.Equal("workflow-def-123", capturedRequest.WorkflowDefinitionHandle.DefinitionVersionId);
     }
 
-    private static (IJobExecutionContext, Mock<QuartzScheduler>) CreateJobExecutionContext(string? jobKeyName = null) =>
-        QuartzJobTestHelper.CreateJobExecutionContext(new Dictionary<string, object>
+    private static (IJobExecutionContext, Mock<QuartzScheduler>) CreateJobExecutionContext(string? jobKeyName = null, bool withTenantId = false)
+    {
+        var jobData = new Dictionary<string, object>
         {
             { "DefinitionVersionId", "workflow-def-123" },
             { "CorrelationId", "corr-123" },
             { "TriggerActivityId", "trigger-123" }
-        }, jobKeyName);
+        };
+
+        if (withTenantId)
+            jobData["TenantId"] = "tenant-123";
+
+        return QuartzJobTestHelper.CreateJobExecutionContext(jobData, jobKeyName);
+    }
 }

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/RunWorkflowJobTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Jobs/RunWorkflowJobTests.cs
@@ -1,5 +1,4 @@
 using Elsa.Common.Multitenancy;
-using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.Contracts;
 using Elsa.Scheduling.Quartz.Jobs;
 using Elsa.Scheduling.Quartz.UnitTests.Helpers;
@@ -18,7 +17,6 @@ public class RunWorkflowJobTests
     private readonly Mock<ITenantAccessor> _tenantAccessor = QuartzJobTestHelper.CreateTenantAccessor();
     private readonly Mock<ITenantFinder> _tenantFinder = new();
     private readonly Mock<IWorkflowStarter> _workflowStarter = new();
-    private readonly Mock<ITransientExceptionDetector> _transientDetector = new();
     private readonly Mock<IQuartzJobRetryScheduler> _retryScheduler = new();
     private readonly Mock<ILogger<RunWorkflowJob>> _logger = new();
     private readonly RunWorkflowJob _job;
@@ -29,7 +27,6 @@ public class RunWorkflowJobTests
             _tenantAccessor.Object,
             _tenantFinder.Object,
             _workflowStarter.Object,
-            _transientDetector.Object,
             _retryScheduler.Object,
             _logger.Object);
     }
@@ -69,17 +66,47 @@ public class RunWorkflowJobTests
     }
 
     [Theory]
-    [InlineData(typeof(TimeoutException), true)]
-    [InlineData(typeof(HttpRequestException), true)]
-    public async Task Execute_TransientException_ReschedulesJob(Type exceptionType, bool isTransient)
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(HttpRequestException))]
+    public async Task Execute_RetryableException_ReschedulesJob(Type exceptionType)
     {
-        var (context, _) = CreateJobExecutionContext();
-        _transientDetector.SetupIsTransient(isTransient);
+        var (context, scheduler) = CreateJobExecutionContext();
+        _retryScheduler.SetupRetry(isRetryable: true);
         _workflowStarter.SetupStartWorkflowThrows((Exception)Activator.CreateInstance(exceptionType)!);
 
         await _job.Execute(context);
 
-        _retryScheduler.Verify(x => x.ScheduleRetryAsync(context, It.IsAny<CancellationToken>()), Times.Once);
+        _retryScheduler.VerifyRetryScheduled(context);
+        _logger.VerifyLogged(LogLevel.Error, Times.Never());
+        scheduler.VerifyNotDeleted();
+    }
+
+    [Fact]
+    public async Task Execute_RetriesExhausted_LogsErrorAndKeepsTheJob()
+    {
+        var (context, scheduler) = CreateJobExecutionContext();
+        _retryScheduler.SetupRetry(isRetryable: true, retryScheduled: false);
+        _workflowStarter.SetupStartWorkflowThrows(new TimeoutException());
+
+        await _job.Execute(context);
+
+        _retryScheduler.VerifyRetryScheduled(context);
+        _logger.VerifyLogged(LogLevel.Error, Times.Once());
+        scheduler.VerifyNotDeleted();
+    }
+
+    [Fact]
+    public async Task Execute_IsRetryableOverrideRejectsTheException_TreatsItAsPermanent()
+    {
+        var (context, scheduler) = CreateJobExecutionContext();
+        _retryScheduler.SetupRetry(isRetryable: false);
+        _workflowStarter.SetupStartWorkflowThrows(new TimeoutException());
+
+        await _job.Execute(context);
+
+        _retryScheduler.Verify(x => x.ScheduleRetryAsync(It.IsAny<IJobExecutionContext>(), It.IsAny<Exception>(), It.IsAny<CancellationToken>()), Times.Never);
+        _logger.VerifyLogged(LogLevel.Error, Times.Once());
+        scheduler.VerifyDeleted();
     }
 
     [Theory]
@@ -90,7 +117,7 @@ public class RunWorkflowJobTests
     public async Task Execute_NonTransientException_DeletesJob(Type exceptionType, string? jobKeyName)
     {
         var (context, scheduler) = CreateJobExecutionContext(jobKeyName);
-        _transientDetector.SetupIsTransient(false);
+        _retryScheduler.SetupRetry(isRetryable: false);
         _workflowStarter.SetupStartWorkflowThrows((Exception)Activator.CreateInstance(exceptionType)!);
 
         await _job.Execute(context);

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Elsa.Common;
 using Elsa.Resilience;
 using Elsa.Scheduling.Quartz.Models;
@@ -128,6 +129,58 @@ public class QuartzJobRetrySchedulerTests
 
         Assert.False(scheduled);
         VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_NegativePersistedAttemptCount_IsClampedToZero()
+    {
+        _options.MaxRetryAttempts = 3;
+        _options.InitialRetryDelay = TimeSpan.FromSeconds(10);
+        var (context, scheduler) = CreateContext(retryAttempt: "-1");
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.True(scheduled);
+        Assert.Equal("1", capturedTrigger()!.JobDataMap[QuartzJobDataKeys.RetryAttempt]);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_PersistedAttemptCountAtIntMaxValue_ReturnsFalseWithoutOverflow()
+    {
+        _options.MaxRetryAttempts = 3;
+        var (context, scheduler) = CreateContext(retryAttempt: int.MaxValue.ToString(CultureInfo.InvariantCulture));
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+        VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_RescheduleJobReturnsNull_ReturnsFalse()
+    {
+        var (context, scheduler) = CreateContext();
+        scheduler
+            .Setup(s => s.RescheduleJob(It.IsAny<TriggerKey>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTimeOffset?)null);
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_DelayIsTimeSpanMaxValue_ClampsStartTimeToDateTimeOffsetMaxValueWithoutThrowing()
+    {
+        _options.DelayGenerator = _ => TimeSpan.MaxValue;
+        var (context, scheduler) = CreateContext();
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.True(scheduled);
+        Assert.Equal(DateTimeOffset.MaxValue, capturedTrigger()!.StartTimeUtc);
     }
 
     [Fact]

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
@@ -1,34 +1,245 @@
 using Elsa.Common;
+using Elsa.Resilience;
+using Elsa.Scheduling.Quartz.Models;
+using Elsa.Scheduling.Quartz.Options;
 using Elsa.Scheduling.Quartz.Services;
 using Elsa.Scheduling.Quartz.UnitTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Quartz;
+using QuartzScheduler = Quartz.IScheduler;
 
 namespace Elsa.Scheduling.Quartz.UnitTests.Services;
 
 public class QuartzJobRetrySchedulerTests
 {
-    [Fact]
-    public async Task ScheduleRetryAsync_UsesSystemClockUtcNowPlusDelay()
-    {
-        var now = new DateTimeOffset(2025, 01, 02, 03, 04, 05, TimeSpan.Zero);
-        var delay = TimeSpan.FromSeconds(10);
-        var clock = new Mock<ISystemClock>();
-        clock.SetupGet(x => x.UtcNow).Returns(now);
+    private static readonly DateTimeOffset Now = new(2025, 01, 02, 03, 04, 05, TimeSpan.Zero);
+    private readonly Mock<ISystemClock> _clock = new();
+    private readonly Mock<ITransientExceptionDetector> _transientDetector = new();
+    private readonly QuartzJobOptions _options = QuartzJobTestHelper.CreateQuartzJobOptions();
+    private readonly Exception _exception = new TimeoutException("Transient");
 
+    public QuartzJobRetrySchedulerTests()
+    {
+        _clock.SetupGet(x => x.UtcNow).Returns(Now);
+        _transientDetector.SetupIsTransient(true);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_FirstRetry_StartsAtNowPlusTheInitialDelay()
+    {
+        _options.InitialRetryDelay = TimeSpan.FromSeconds(10);
+        var (context, scheduler) = CreateContext();
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.True(scheduled);
+        Assert.Equal(Now.Add(TimeSpan.FromSeconds(10)), capturedTrigger()!.StartTimeUtc);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_SecondRetry_AppliesExponentialBackoff()
+    {
+        _options.InitialRetryDelay = TimeSpan.FromSeconds(10);
+        var (context, scheduler) = CreateContext(retryAttempt: "1");
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        Assert.Equal(Now.Add(TimeSpan.FromSeconds(20)), capturedTrigger()!.StartTimeUtc);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_PersistsTheIncrementedAttemptAndPreservesTriggerData()
+    {
+        var (context, scheduler) = CreateContext(retryAttempt: "1");
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        var jobDataMap = capturedTrigger()!.JobDataMap;
+        Assert.Equal("2", jobDataMap[QuartzJobDataKeys.RetryAttempt]);
+        Assert.Equal("workflow-def-123", jobDataMap["DefinitionVersionId"]);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_KeepsTheOriginalTriggerKeySoTheRetryRemainsAddressable()
+    {
+        var (context, scheduler) = CreateContext();
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        Assert.Equal(context.Trigger.Key, capturedTrigger()!.Key);
+        Assert.Equal(context.JobDetail.Key, capturedTrigger()!.JobKey);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_RetriesDisabled_ReturnsFalseAndDoesNotReschedule()
+    {
+        _options.RetryEnabled = false;
+        var (context, scheduler) = CreateContext();
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+        VerifyNotRescheduled(scheduler);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("1", true)]
+    [InlineData("2", true)]
+    [InlineData("3", false)]
+    [InlineData("4", false)]
+    public async Task ScheduleRetryAsync_StopsOnceTheMaximumNumberOfAttemptsIsReached(string? retryAttempt, bool expectedScheduled)
+    {
+        _options.MaxRetryAttempts = 3;
+        var (context, scheduler) = CreateContext(retryAttempt);
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.Equal(expectedScheduled, scheduled);
+
+        if (!expectedScheduled)
+            VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_ZeroMaximumAttempts_ReturnsFalse()
+    {
+        _options.MaxRetryAttempts = 0;
+        var (context, scheduler) = CreateContext();
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+        VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_DelayGenerator_OverridesTheComputedDelay()
+    {
+        _options.InitialRetryDelay = TimeSpan.FromSeconds(10);
+        _options.MaxRetryAttempts = 7;
+        QuartzJobRetryContext? capturedRetryContext = null;
+        _options.DelayGenerator = retryContext =>
+        {
+            capturedRetryContext = retryContext;
+            return TimeSpan.FromSeconds(42);
+        };
+        var (context, scheduler) = CreateContext(retryAttempt: "1");
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        Assert.Equal(Now.Add(TimeSpan.FromSeconds(42)), capturedTrigger()!.StartTimeUtc);
+        Assert.NotNull(capturedRetryContext);
+        Assert.Equal(2, capturedRetryContext!.AttemptNumber);
+        Assert.Equal(7, capturedRetryContext.MaxRetryAttempts);
+        Assert.Equal(TimeSpan.FromSeconds(20), capturedRetryContext.ComputedDelay);
+        Assert.Same(_exception, capturedRetryContext.Exception);
+        Assert.Equal(context.JobDetail.Key, capturedRetryContext.JobKey);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_DelayGeneratorReturningNull_FallsBackToTheComputedDelay()
+    {
+        _options.InitialRetryDelay = TimeSpan.FromSeconds(10);
+        _options.DelayGenerator = _ => null;
+        var (context, scheduler) = CreateContext();
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        Assert.Equal(Now.Add(TimeSpan.FromSeconds(10)), capturedTrigger()!.StartTimeUtc);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_DelayGeneratorReturningANegativeDelay_SchedulesImmediately()
+    {
+        _options.DelayGenerator = _ => TimeSpan.FromSeconds(-10);
+        var (context, scheduler) = CreateContext();
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        Assert.Equal(Now, capturedTrigger()!.StartTimeUtc);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_ObsoleteRetryDelay_ConfiguresTheInitialDelay()
+    {
+#pragma warning disable CS0618 // The obsolete property must keep working for existing configuration.
+        _options.TransientExceptionRetryDelay = TimeSpan.FromSeconds(10);
+        Assert.Equal(TimeSpan.FromSeconds(10), _options.InitialRetryDelay);
+
+        _options.InitialRetryDelay = TimeSpan.FromSeconds(3);
+        Assert.Equal(TimeSpan.FromSeconds(3), _options.TransientExceptionRetryDelay);
+#pragma warning restore CS0618
+
+        var (context, scheduler) = CreateContext();
+        var capturedTrigger = CaptureTrigger(scheduler);
+
+        await ScheduleRetryAsync(context);
+
+        Assert.Equal(Now.Add(TimeSpan.FromSeconds(3)), capturedTrigger()!.StartTimeUtc);
+    }
+
+    [Fact]
+    public void IsRetryable_WithoutOverride_DefersToTheTransientExceptionDetector()
+    {
+        _transientDetector.SetupIsTransient(false);
+
+        Assert.False(CreateSut().IsRetryable(_exception));
+
+        _transientDetector.SetupIsTransient(true);
+
+        Assert.True(CreateSut().IsRetryable(_exception));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void IsRetryable_WithOverride_IgnoresTheTransientExceptionDetector(bool overrideResult, bool detectorResult)
+    {
+        _transientDetector.SetupIsTransient(detectorResult);
+        _options.IsRetryable = _ => overrideResult;
+
+        Assert.Equal(overrideResult, CreateSut().IsRetryable(_exception));
+        _transientDetector.Verify(x => x.IsTransient(It.IsAny<Exception>()), Times.Never);
+    }
+
+    private Task<bool> ScheduleRetryAsync(IJobExecutionContext context) => CreateSut().ScheduleRetryAsync(context, _exception);
+
+    private QuartzJobRetryScheduler CreateSut() =>
+        new(_clock.Object, _options.AsOptions(), new QuartzRetryDelayCalculator(), _transientDetector.Object, NullLogger<QuartzJobRetryScheduler>.Instance);
+
+    private static (IJobExecutionContext Context, Mock<QuartzScheduler> Scheduler) CreateContext(string? retryAttempt = null)
+    {
+        var triggerData = new Dictionary<string, object>
+        {
+            ["DefinitionVersionId"] = "workflow-def-123"
+        };
+
+        if (retryAttempt != null)
+            triggerData[QuartzJobDataKeys.RetryAttempt] = retryAttempt;
+
+        return QuartzJobTestHelper.CreateJobExecutionContext(new Dictionary<string, object>(), triggerData: triggerData);
+    }
+
+    private static Func<ITrigger?> CaptureTrigger(Mock<QuartzScheduler> scheduler)
+    {
         ITrigger? capturedTrigger = null;
-        var (context, scheduler) = QuartzJobTestHelper.CreateJobExecutionContext(new Dictionary<string, object>());
         scheduler
             .Setup(s => s.RescheduleJob(It.IsAny<TriggerKey>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()))
             .Callback<TriggerKey, ITrigger, CancellationToken>((_, t, _) => capturedTrigger = t)
-            .ReturnsAsync(now);
+            .ReturnsAsync(Now);
 
-        var options = QuartzJobTestHelper.CreateQuartzJobOptions(delay);
-        var sut = new QuartzJobRetryScheduler(clock.Object, options.Object);
-
-        await sut.ScheduleRetryAsync(context);
-
-        Assert.NotNull(capturedTrigger);
-        Assert.Equal(now.Add(delay), capturedTrigger!.StartTimeUtc);
+        return () => capturedTrigger;
     }
+
+    private static void VerifyNotRescheduled(Mock<QuartzScheduler> scheduler) =>
+        scheduler.Verify(s => s.RescheduleJob(It.IsAny<TriggerKey>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Never);
 }

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
@@ -158,6 +158,30 @@ public class QuartzJobRetrySchedulerTests
     }
 
     [Fact]
+    public async Task ScheduleRetryAsync_PersistedAttemptCountAtLongMaxValue_ReturnsFalseWithoutOverflow()
+    {
+        _options.MaxRetryAttempts = 3;
+        var (context, scheduler) = CreateContext(retryAttempt: long.MaxValue);
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+        VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_PersistedAttemptCountAsStringBeyondIntRange_ReturnsFalseWithoutOverflow()
+    {
+        _options.MaxRetryAttempts = 3;
+        var (context, scheduler) = CreateContext(retryAttempt: "9999999999");
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+        VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
     public async Task ScheduleRetryAsync_RescheduleJobReturnsNull_ReturnsFalse()
     {
         var (context, scheduler) = CreateContext();
@@ -281,7 +305,7 @@ public class QuartzJobRetrySchedulerTests
     private QuartzJobRetryScheduler CreateSut() =>
         new(_clock.Object, _options.AsOptions(), new QuartzRetryDelayCalculator(), _transientDetector.Object, NullLogger<QuartzJobRetryScheduler>.Instance);
 
-    private static (IJobExecutionContext Context, Mock<QuartzScheduler> Scheduler) CreateContext(string? retryAttempt = null)
+    private static (IJobExecutionContext Context, Mock<QuartzScheduler> Scheduler) CreateContext(object? retryAttempt = null)
     {
         var triggerData = new Dictionary<string, object>
         {

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzJobRetrySchedulerTests.cs
@@ -119,6 +119,18 @@ public class QuartzJobRetrySchedulerTests
     }
 
     [Fact]
+    public async Task ScheduleRetryAsync_NegativeMaximumAttempts_ReturnsFalse()
+    {
+        _options.MaxRetryAttempts = -1;
+        var (context, scheduler) = CreateContext();
+
+        var scheduled = await ScheduleRetryAsync(context);
+
+        Assert.False(scheduled);
+        VerifyNotRescheduled(scheduler);
+    }
+
+    [Fact]
     public async Task ScheduleRetryAsync_DelayGenerator_OverridesTheComputedDelay()
     {
         _options.InitialRetryDelay = TimeSpan.FromSeconds(10);

--- a/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzRetryDelayCalculatorTests.cs
+++ b/test/modules/scheduling/Elsa.Scheduling.Quartz.UnitTests/Services/QuartzRetryDelayCalculatorTests.cs
@@ -1,0 +1,167 @@
+using Elsa.Scheduling.Quartz.Options;
+using Elsa.Scheduling.Quartz.Services;
+
+namespace Elsa.Scheduling.Quartz.UnitTests.Services;
+
+public class QuartzRetryDelayCalculatorTests
+{
+    private static readonly TimeSpan Initial = TimeSpan.FromSeconds(1);
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(4, 8)]
+    public void CalculateDelay_Exponential_DoublesEveryAttempt(int attempt, int expectedSeconds)
+    {
+        var delay = Calculate(attempt, RetryBackoffType.Exponential);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 3)]
+    [InlineData(4, 4)]
+    public void CalculateDelay_Linear_GrowsByTheInitialDelay(int attempt, int expectedSeconds)
+    {
+        var delay = Calculate(attempt, RetryBackoffType.Linear);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), delay);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(10)]
+    public void CalculateDelay_Constant_AlwaysReturnsTheInitialDelay(int attempt)
+    {
+        var delay = Calculate(attempt, RetryBackoffType.Constant);
+
+        Assert.Equal(Initial, delay);
+    }
+
+    [Theory]
+    [InlineData(RetryBackoffType.Exponential)]
+    [InlineData(RetryBackoffType.Linear)]
+    [InlineData(RetryBackoffType.Constant)]
+    public void CalculateDelay_FirstAttempt_ReturnsTheInitialDelay(RetryBackoffType backoffType)
+    {
+        var delay = Calculate(1, backoffType);
+
+        Assert.Equal(Initial, delay);
+    }
+
+    [Fact]
+    public void CalculateDelay_GrowthBeyondTheMaximum_IsCapped()
+    {
+        var maxRetryDelay = TimeSpan.FromSeconds(30);
+        var delay = Calculate(10, RetryBackoffType.Exponential, options => options.MaxRetryDelay = maxRetryDelay);
+
+        Assert.Equal(maxRetryDelay, delay);
+    }
+
+    [Fact]
+    public void CalculateDelay_ExtremeAttemptNumber_DoesNotOverflow()
+    {
+        var delay = Calculate(2000, RetryBackoffType.Exponential, options => options.MaxRetryDelay = TimeSpan.FromMinutes(1));
+
+        Assert.Equal(TimeSpan.FromMinutes(1), delay);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.8)]
+    [InlineData(0.5, 1.0)]
+    [InlineData(0.9999, 1.2)]
+    public void CalculateDelay_WithJitter_ScalesTheDelayByTheRandomFactor(double randomValue, double expectedFactor)
+    {
+        var options = QuartzJobOptionsFor(RetryBackoffType.Constant, o => o.UseJitter = true);
+        var calculator = new QuartzRetryDelayCalculator(new FixedRandom(randomValue));
+
+        var delay = calculator.CalculateDelay(1, options);
+
+        Assert.Equal(Initial.Ticks * expectedFactor, delay.Ticks, Initial.Ticks * 0.001);
+    }
+
+    [Fact]
+    public void CalculateDelay_WithJitter_StaysWithinTheJitterBounds()
+    {
+        var options = QuartzJobOptionsFor(RetryBackoffType.Exponential, o => o.UseJitter = true);
+        var calculator = new QuartzRetryDelayCalculator(new Random(1234));
+
+        for (var attempt = 1; attempt <= 5; attempt++)
+        {
+            var expected = Initial.Ticks * Math.Pow(2, attempt - 1);
+            var delay = calculator.CalculateDelay(attempt, options);
+
+            Assert.InRange(delay.Ticks, (long)(expected * QuartzRetryDelayCalculator.MinJitterFactor), (long)(expected * QuartzRetryDelayCalculator.MaxJitterFactor));
+        }
+    }
+
+    [Fact]
+    public void CalculateDelay_WithJitter_IsCappedAfterJitterIsApplied()
+    {
+        var options = QuartzJobOptionsFor(RetryBackoffType.Constant, o =>
+        {
+            o.UseJitter = true;
+            o.MaxRetryDelay = Initial;
+        });
+        var calculator = new QuartzRetryDelayCalculator(new FixedRandom(0.9999));
+
+        var delay = calculator.CalculateDelay(1, options);
+
+        Assert.Equal(Initial, delay);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void CalculateDelay_AttemptNumberBelowOne_IsTreatedAsTheFirstAttempt(int attempt)
+    {
+        var delay = Calculate(attempt, RetryBackoffType.Exponential);
+
+        Assert.Equal(Initial, delay);
+    }
+
+    [Fact]
+    public void CalculateDelay_NonPositiveInitialDelay_ReturnsZero()
+    {
+        var delay = Calculate(3, RetryBackoffType.Exponential, options => options.InitialRetryDelay = TimeSpan.Zero);
+
+        Assert.Equal(TimeSpan.Zero, delay);
+    }
+
+    [Fact]
+    public void CalculateDelay_NonPositiveMaximumDelay_DoesNotCap()
+    {
+        var delay = Calculate(3, RetryBackoffType.Exponential, options => options.MaxRetryDelay = TimeSpan.Zero);
+
+        Assert.Equal(TimeSpan.FromSeconds(4), delay);
+    }
+
+    private static TimeSpan Calculate(int attempt, RetryBackoffType backoffType, Action<QuartzJobOptions>? configure = null) =>
+        new QuartzRetryDelayCalculator().CalculateDelay(attempt, QuartzJobOptionsFor(backoffType, configure));
+
+    private static QuartzJobOptions QuartzJobOptionsFor(RetryBackoffType backoffType, Action<QuartzJobOptions>? configure = null)
+    {
+        var options = new QuartzJobOptions
+        {
+            InitialRetryDelay = Initial,
+            MaxRetryDelay = TimeSpan.FromDays(1),
+            BackoffType = backoffType,
+            UseJitter = false
+        };
+
+        configure?.Invoke(options);
+        return options;
+    }
+
+    /// <summary>
+    /// A random source that always yields the same value, making jitter deterministic.
+    /// </summary>
+    private sealed class FixedRandom(double value) : Random
+    {
+        public override double NextDouble() => value;
+    }
+}


### PR DESCRIPTION
Closes #102

Completes the retry policy for the Quartz workflow jobs on top of #104, which added transient-failure detection and a fixed-delay reschedule.

## What changed
- **Configurable policy** on `QuartzJobOptions`: `RetryEnabled` (true), `MaxRetryAttempts` (5), `InitialRetryDelay` (500 ms), `MaxRetryDelay` (1 min), `BackoffType` (Exponential, Linear, Constant), `UseJitter` (true), plus a `DelayGenerator` delegate for custom strategies and an `IsRetryable` delegate to override exception filtering. `TransientExceptionRetryDelay` is kept as an obsolete alias of `InitialRetryDelay` so existing configuration keeps working.
- **Bounded, durable retries**: each retry is still scheduled as a Quartz trigger (so it survives restarts and never pins a worker thread), but the attempt number is now persisted on the trigger's job data and retries stop once the maximum is reached. `IQuartzJobRetryScheduler.ScheduleRetryAsync` returns whether a retry was scheduled; the jobs log an Error and stop when retries are disabled or exhausted.
- **Backoff with jitter** computed by a new `IQuartzRetryDelayCalculator` (Polly-style semantics: exponential growth from the initial delay, uniform jitter factor 0.8 to 1.2, capped at the maximum delay). Polly's own delay generation is internal and an in-process Polly loop would lose progress on restart, so the durable trigger design was kept.
- **Logging**: every retry logs a Warning with the job key, attempt number, maximum, delay, and exception.
- **Bug fix found on the way**: the #104 scheduler rebuilt the trigger without the failed trigger's job data or key. Elsa places the workflow payload on the trigger, so the first retry would have run with an empty data map, and unscheduling by name would have missed the retry trigger. The retry trigger now carries the original job data and keeps the original key.

## Notes
- Default behavior changes for deployments that never configured retries: from unbounded retries every 10 seconds to five retries with exponential backoff (about 15 seconds in total). This is documented on `MaxRetryAttempts`; raise `MaxRetryAttempts` and `MaxRetryDelay` to retry through longer outages.
- The issue's advisory-lock point is already covered in elsa-core: `DistributedWorkflowClient` logs and swallows lock-release failures on broken connections.
- Known limitation inherited from #104 and left for a follow-up: retrying replaces the firing trigger, so a transient failure on a recurring (cron) trigger turns it into a one-shot retry and the recurrence is lost. Fixing that needs a separate retry trigger rather than a reschedule.
- Constructor changes: `RunWorkflowJob` and `ResumeWorkflowJob` no longer take `ITransientExceptionDetector` (the scheduler decides via `IsRetryable`); both are constructed by Quartz through DI.

## Verification
- `Elsa.Scheduling.Quartz.UnitTests`: 82 passed (calculator math, attempt persistence and data preservation, exhaustion, disabled and negative attempts, obsolete alias, override filter).
- `Elsa.Scheduling.Quartz.ComponentTests`: 5 passed, including a job succeeding on its third attempt against a real scheduler and one stopping after exhaustion.
- Mutation check: disabling the job-data copy or the attempt persistence fails 1 unit and 3 component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)