### PR TITLE
fix(actors): refresh workflow graph when importing state

### DIFF
--- a/Elsa.Extensions.sln
+++ b/Elsa.Extensions.sln
@@ -326,6 +326,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Mqtt.UnitTests", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.Dapper.UnitTests", "test\modules\persistence\Elsa.Persistence.Dapper.UnitTests\Elsa.Persistence.Dapper.UnitTests.csproj", "{C115D266-ED50-4584-B059-B4BB48B54C77}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtimes", "runtimes", "{743A35F0-4B12-4C73-928F-7DA1A3EEFA73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Workflows.Runtime.ProtoActor.UnitTests", "test\modules\runtimes\Elsa.Workflows.Runtime.ProtoActor.UnitTests\Elsa.Workflows.Runtime.ProtoActor.UnitTests.csproj", "{209765CA-207B-44F0-94E4-0711235E7F99}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -336,6 +340,18 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Debug|x64.Build.0 = Debug|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Debug|x86.Build.0 = Debug|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Release|x64.ActiveCfg = Release|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Release|x64.Build.0 = Release|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Release|x86.ActiveCfg = Release|Any CPU
+		{209765CA-207B-44F0-94E4-0711235E7F99}.Release|x86.Build.0 = Release|Any CPU
 		{4D16DD17-0BC9-476D-9B38-0A8644DD92FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4D16DD17-0BC9-476D-9B38-0A8644DD92FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D16DD17-0BC9-476D-9B38-0A8644DD92FE}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -1557,6 +1573,8 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{743A35F0-4B12-4C73-928F-7DA1A3EEFA73} = {3DDE6F89-531C-47F8-9CD7-7A4E6984FA48}
+		{209765CA-207B-44F0-94E4-0711235E7F99} = {743A35F0-4B12-4C73-928F-7DA1A3EEFA73}
 		{3948BAF0-023F-4B43-8E77-56C3B00C6EFD} = {D0212324-351E-4CA6-95EE-27754B5367CC}
 		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {30CF0330-4B09-4784-B499-46BED303810B}
 		{45B793EC-7BFF-45C0-BD0E-2D1601C8D01E} = {30CF0330-4B09-4784-B499-46BED303810B}

--- a/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Actors/WorkflowInstance.cs
+++ b/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Actors/WorkflowInstance.cs
@@ -196,10 +196,19 @@ internal class WorkflowInstance(
     {
         var workflowState = mappers.WorkflowStateJsonMapper.Map(request.SerializedWorkflowState);
         await EnsureStateAsync();
-        WorkflowState = workflowState;
+        var workflowGraph = WorkflowGraph;
+
+        if (workflowGraph.Workflow.Identity.Id != workflowState.DefinitionVersionId)
+        {
+            var workflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionVersionId(workflowState.DefinitionVersionId);
+            workflowGraph = await FindWorkflowGraphAsync(workflowDefinitionHandle, Context.CancellationToken);
+        }
+
         await using var scope = scopeFactory.CreateAsyncScope();
         var workflowInstanceManager = scope.ServiceProvider.GetRequiredService<IWorkflowInstanceManager>();
-        await workflowInstanceManager.SaveAsync(WorkflowState, Context.CancellationToken);
+        await workflowInstanceManager.SaveAsync(workflowState, Context.CancellationToken);
+        WorkflowGraph = workflowGraph;
+        WorkflowState = workflowState;
     }
 
     public override Task<InstanceExistsResponse> InstanceExists()

--- a/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Elsa.Workflows.Runtime.ProtoActor.csproj
+++ b/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Elsa.Workflows.Runtime.ProtoActor.csproj
@@ -26,6 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Elsa.Workflows.Runtime.ProtoActor.UnitTests"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <Protobuf Include="Proto\Shared.proto" AdditionalImportDirs="./Proto"/>
         <Protobuf Include="Proto\WorkflowInstance.Messages.proto" AdditionalImportDirs="./Proto"/>
         <ProtoGrain Include="Proto\WorkflowInstance.proto" AdditionalImportDirs="./Proto" TemplateFiles="./Templates/Grain.tt"/>

--- a/test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Actors/WorkflowInstanceImportStateTests.cs
+++ b/test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Actors/WorkflowInstanceImportStateTests.cs
@@ -1,0 +1,114 @@
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Options;
+using Elsa.Workflows.Runtime.ProtoActor.UnitTests.Fixtures;
+using Elsa.Workflows.State;
+using Moq;
+using Proto.Cluster;
+using ProtoRunWorkflowInstanceResponse = Elsa.Workflows.Runtime.ProtoActor.ProtoBuf.RunWorkflowInstanceResponse;
+
+namespace Elsa.Workflows.Runtime.ProtoActor.UnitTests.Actors;
+
+public class WorkflowInstanceImportStateTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task ImportState_WhenAlterationMigratesDefinition_RefreshesWorkflowGraph()
+    {
+        await using var harness = new WorkflowInstanceTestHarness();
+        using var timeout = new CancellationTokenSource(TestTimeout);
+        var initialState = WorkflowInstanceTestHarness.CreateState();
+        var migratedState = WorkflowInstanceTestHarness.CreateState("definition-version-2", 2);
+        var migratedGraph = WorkflowInstanceTestHarness.CreateWorkflowGraph(migratedState.DefinitionVersionId, migratedState.DefinitionVersion);
+        harness.SetupExistingInstance(initialState);
+        harness.WorkflowDefinitionService
+            .Setup(x => x.FindWorkflowGraphAsync(
+                It.Is<WorkflowDefinitionHandle>(handle => handle.DefinitionVersionId == migratedState.DefinitionVersionId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(migratedGraph);
+
+        // Alterations import the migrated state through IWorkflowClient before the next run.
+        Assert.IsType<GrainResponseMessage>(await harness.ImportStateAsync(migratedState, timeout.Token));
+        harness.WorkflowInstanceManager.Verify(x => x.SaveAsync(migratedState, It.IsAny<CancellationToken>()), Times.Once);
+        Assert.IsType<ProtoRunWorkflowInstanceResponse>(await harness.RunAsync(timeout.Token));
+
+        harness.WorkflowRunner.Verify(x => x.RunAsync(
+            migratedGraph, migratedState, It.IsAny<RunWorkflowOptions?>(), It.IsAny<CancellationToken>()), Times.Once);
+        harness.WorkflowDefinitionService.Verify(x => x.FindWorkflowGraphAsync(
+            It.Is<WorkflowDefinitionHandle>(handle => handle.DefinitionVersionId == WorkflowInstanceTestHarness.DefinitionVersionId),
+            It.IsAny<CancellationToken>()), Times.Once);
+        harness.WorkflowDefinitionService.Verify(x => x.FindWorkflowGraphAsync(
+            It.Is<WorkflowDefinitionHandle>(handle => handle.DefinitionVersionId == migratedState.DefinitionVersionId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportState_WhenDefinitionVersionIsUnchanged_ReusesCachedWorkflowGraph()
+    {
+        await using var harness = new WorkflowInstanceTestHarness();
+        using var timeout = new CancellationTokenSource(TestTimeout);
+        var initialState = WorkflowInstanceTestHarness.CreateState();
+        var importedState = WorkflowInstanceTestHarness.CreateState();
+        importedState.Properties["alteration"] = "same-version";
+        harness.SetupExistingInstance(initialState);
+
+        Assert.IsType<GrainResponseMessage>(await harness.ImportStateAsync(importedState, timeout.Token));
+        harness.WorkflowInstanceManager.Verify(x => x.SaveAsync(importedState, It.IsAny<CancellationToken>()), Times.Once);
+        Assert.IsType<ProtoRunWorkflowInstanceResponse>(await harness.RunAsync(timeout.Token));
+
+        harness.WorkflowRunner.Verify(x => x.RunAsync(
+            harness.WorkflowGraph, importedState, It.IsAny<RunWorkflowOptions?>(), It.IsAny<CancellationToken>()), Times.Once);
+        harness.WorkflowDefinitionService.Verify(x => x.FindWorkflowGraphAsync(
+            It.IsAny<WorkflowDefinitionHandle>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportState_WhenImportedDefinitionGraphIsMissing_PreservesCachedPairAndDoesNotSave()
+    {
+        await using var harness = new WorkflowInstanceTestHarness();
+        using var timeout = new CancellationTokenSource(TestTimeout);
+        var initialState = WorkflowInstanceTestHarness.CreateState();
+        var migratedState = WorkflowInstanceTestHarness.CreateState("missing-definition-version", 2);
+        harness.SetupExistingInstance(initialState);
+        harness.WorkflowDefinitionService
+            .Setup(x => x.FindWorkflowGraphAsync(
+                It.Is<WorkflowDefinitionHandle>(handle => handle.DefinitionVersionId == migratedState.DefinitionVersionId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowGraph?)null);
+
+        var error = Assert.IsType<GrainErrorResponse>(await harness.ImportStateAsync(migratedState, timeout.Token));
+        Assert.Contains("missing-definition-version", error.Err);
+        harness.WorkflowInstanceManager.Verify(x => x.SaveAsync(It.IsAny<WorkflowState>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.IsType<ProtoRunWorkflowInstanceResponse>(await harness.RunAsync(timeout.Token));
+
+        harness.WorkflowRunner.Verify(x => x.RunAsync(
+            harness.WorkflowGraph, initialState, It.IsAny<RunWorkflowOptions?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportState_WhenSavingImportedStateFails_PreservesCachedGraphAndState()
+    {
+        await using var harness = new WorkflowInstanceTestHarness();
+        using var timeout = new CancellationTokenSource(TestTimeout);
+        var initialState = WorkflowInstanceTestHarness.CreateState();
+        var migratedState = WorkflowInstanceTestHarness.CreateState("definition-version-2", 2);
+        var migratedGraph = WorkflowInstanceTestHarness.CreateWorkflowGraph(migratedState.DefinitionVersionId, migratedState.DefinitionVersion);
+        harness.SetupExistingInstance(initialState);
+        harness.WorkflowDefinitionService
+            .Setup(x => x.FindWorkflowGraphAsync(
+                It.Is<WorkflowDefinitionHandle>(handle => handle.DefinitionVersionId == migratedState.DefinitionVersionId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(migratedGraph);
+        harness.WorkflowInstanceManager
+            .Setup(x => x.SaveAsync(migratedState, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Import persistence failed."));
+
+        var error = Assert.IsType<GrainErrorResponse>(await harness.ImportStateAsync(migratedState, timeout.Token));
+        Assert.Contains("Import persistence failed.", error.Err);
+        harness.WorkflowInstanceManager.Verify(x => x.SaveAsync(migratedState, It.IsAny<CancellationToken>()), Times.Once);
+        Assert.IsType<ProtoRunWorkflowInstanceResponse>(await harness.RunAsync(timeout.Token));
+
+        harness.WorkflowRunner.Verify(x => x.RunAsync(
+            harness.WorkflowGraph, initialState, It.IsAny<RunWorkflowOptions?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Elsa.Workflows.Runtime.ProtoActor.UnitTests.csproj
+++ b/test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Elsa.Workflows.Runtime.ProtoActor.UnitTests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\..\src\modules\runtimes\Elsa.Workflows.Runtime.ProtoActor\Elsa.Workflows.Runtime.ProtoActor.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Fixtures/WorkflowInstanceTestHarness.cs
+++ b/test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Fixtures/WorkflowInstanceTestHarness.cs
@@ -1,0 +1,158 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Options;
+using Elsa.Workflows.Runtime.ProtoActor.Mappers;
+using Elsa.Workflows.State;
+using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Proto;
+using Proto.Cluster;
+using ProtoActorMappers = Elsa.Workflows.Runtime.ProtoActor.Mappers.Mappers;
+using ProtoImportWorkflowStateRequest = Elsa.Workflows.Runtime.ProtoActor.ProtoBuf.ImportWorkflowStateRequest;
+using ProtoRunWorkflowInstanceRequest = Elsa.Workflows.Runtime.ProtoActor.ProtoBuf.RunWorkflowInstanceRequest;
+using ProtoWorkflowInstanceActor = Elsa.Workflows.Runtime.ProtoActor.ProtoBuf.WorkflowInstanceActor;
+using WorkflowInstanceActorImplementation = Elsa.Workflows.Runtime.ProtoActor.Actors.WorkflowInstance;
+using WorkflowInstanceEntity = Elsa.Workflows.Management.Entities.WorkflowInstance;
+
+namespace Elsa.Workflows.Runtime.ProtoActor.UnitTests.Fixtures;
+
+internal sealed class WorkflowInstanceTestHarness : IAsyncDisposable
+{
+    public const string DefinitionId = "definition";
+    public const string DefinitionVersionId = "definition-version";
+    private const string InstanceId = "instance";
+    private const int RunMethodIndex = 1;
+    private const int ImportStateMethodIndex = 7;
+
+    private readonly ActorSystem _actorSystem = new();
+    private readonly ServiceProvider _serviceProvider;
+    private readonly PID _workflowInstanceActor;
+    private readonly Mock<IWorkflowStateSerializer> _workflowStateSerializer = new();
+
+    public WorkflowInstanceTestHarness()
+    {
+        WorkflowGraph = CreateWorkflowGraph(DefinitionVersionId, 1);
+        WorkflowDefinitionService
+            .Setup(x => x.FindWorkflowGraphAsync(It.IsAny<WorkflowDefinitionHandle>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WorkflowGraph);
+        WorkflowInstanceManager
+            .Setup(x => x.SaveAsync(It.IsAny<WorkflowState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowState state, CancellationToken _) => CreateWorkflowInstance(state));
+        WorkflowRunner
+            .Setup(x => x.RunAsync(It.IsAny<WorkflowGraph>(), It.IsAny<WorkflowState>(), It.IsAny<RunWorkflowOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WorkflowGraph graph, WorkflowState state, RunWorkflowOptions? _, CancellationToken _) =>
+                new RunWorkflowResult(null!, state, graph.Workflow, null, Journal.Empty));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(WorkflowRunner.Object);
+        services.AddSingleton(WorkflowInstanceManager.Object);
+        services.AddSingleton(WorkflowDefinitionService.Object);
+        _serviceProvider = services.BuildServiceProvider();
+
+        var scopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
+        var mappers = CreateMappers();
+        var props = Props.FromProducer(() => new ProtoWorkflowInstanceActor(
+            (context, _) => new WorkflowInstanceActorImplementation(context, scopeFactory, mappers)));
+        _workflowInstanceActor = _actorSystem.Root.Spawn(
+            props,
+            context => context.Set(ClusterIdentity.Create(InstanceId, ProtoWorkflowInstanceActor.Kind)));
+    }
+
+    public Mock<IWorkflowRunner> WorkflowRunner { get; } = new();
+    public Mock<IWorkflowInstanceManager> WorkflowInstanceManager { get; } = new();
+    public Mock<IWorkflowDefinitionService> WorkflowDefinitionService { get; } = new();
+    public WorkflowGraph WorkflowGraph { get; }
+
+    public static WorkflowState CreateState(string definitionVersionId = DefinitionVersionId, int definitionVersion = 1) => new()
+    {
+        Id = InstanceId,
+        DefinitionId = DefinitionId,
+        DefinitionVersionId = definitionVersionId,
+        DefinitionVersion = definitionVersion,
+        Status = WorkflowStatus.Running,
+        SubStatus = WorkflowSubStatus.Suspended
+    };
+
+    public static WorkflowGraph CreateWorkflowGraph(string definitionVersionId, int definitionVersion)
+    {
+        var workflow = new Workflow
+        {
+            Id = $"workflow-{definitionVersion}",
+            Identity = new(DefinitionId, definitionVersion, definitionVersionId)
+        };
+        var root = new ActivityNode(workflow, "");
+        return new(workflow, root, [root]);
+    }
+
+    public void SetupExistingInstance(WorkflowState state) => WorkflowInstanceManager
+        .Setup(x => x.FindByIdAsync(InstanceId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(CreateWorkflowInstance(state));
+
+    public Task<object> ImportStateAsync(WorkflowState state, CancellationToken cancellationToken)
+    {
+        var serializedState = Guid.NewGuid().ToString("N");
+        _workflowStateSerializer.Setup(x => x.Deserialize(serializedState)).Returns(state);
+        var request = new ProtoImportWorkflowStateRequest
+        {
+            SerializedWorkflowState = new() { Text = serializedState }
+        };
+        return RequestAsync(ImportStateMethodIndex, request, cancellationToken);
+    }
+
+    public Task<object> RunAsync(CancellationToken cancellationToken) => RequestAsync(
+        RunMethodIndex,
+        new ProtoRunWorkflowInstanceRequest { ActivityHandle = new() },
+        cancellationToken);
+
+    public async ValueTask DisposeAsync()
+    {
+        await _actorSystem.Root.PoisonAsync(_workflowInstanceActor);
+        await _actorSystem.ShutdownAsync();
+        await _serviceProvider.DisposeAsync();
+    }
+
+    private async Task<object> RequestAsync(int methodIndex, IMessage message, CancellationToken cancellationToken)
+    {
+        using var future = _actorSystem.Root.GetFuture();
+        _actorSystem.Root.Request(_workflowInstanceActor, new GrainRequestMessage(methodIndex, message), future.Pid);
+        return await future.GetTask(cancellationToken);
+    }
+
+    private static WorkflowInstanceEntity CreateWorkflowInstance(WorkflowState state) => new()
+    {
+        Id = state.Id,
+        DefinitionId = state.DefinitionId,
+        DefinitionVersionId = state.DefinitionVersionId,
+        Version = state.DefinitionVersion,
+        WorkflowState = state,
+        Status = state.Status,
+        SubStatus = state.SubStatus
+    };
+
+    private ProtoActorMappers CreateMappers()
+    {
+        var activityHandleMapper = new ActivityHandleMapper();
+        var workflowDefinitionHandleMapper = new WorkflowDefinitionHandleMapper();
+        var exceptionMapper = new ExceptionMapper();
+        var activityIncidentMapper = new ActivityIncidentMapper(exceptionMapper);
+        var workflowStatusMapper = new WorkflowStatusMapper();
+        var workflowSubStatusMapper = new WorkflowSubStatusMapper();
+
+        return new(
+            activityHandleMapper,
+            workflowDefinitionHandleMapper,
+            activityIncidentMapper,
+            exceptionMapper,
+            workflowStatusMapper,
+            workflowSubStatusMapper,
+            new(workflowDefinitionHandleMapper),
+            new(),
+            new(activityHandleMapper),
+            new(workflowStatusMapper, workflowSubStatusMapper, activityIncidentMapper),
+            new(workflowDefinitionHandleMapper, activityHandleMapper),
+            new(activityHandleMapper),
+            new(_workflowStateSerializer.Object));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #181.

Refresh the Proto.Actor workflow instance’s cached graph when imported state references a different definition version, keeping the graph and state consistent for subsequent execution.

## Problem

`WorkflowInstance.ImportState` replaces the cached state but retains the previous workflow graph. The next run therefore receives the old graph together with the imported state.

The cached state is also replaced before persistence succeeds, leaving it changed even when saving the import fails.

## Changes

- Resolve the target graph when the imported `DefinitionVersionId` differs from the cached graph.
- Reuse the graph for same-version imports.
- Update cached graph and state only after persistence succeeds.
- Preserve the previous cached values when graph lookup or persistence fails.
- Add four regression tests and register the new Proto.Actor runtime test project in the solution.

No public API or dependency changes.

## Reproduction

1. Load a workflow instance referencing definition version 1 into a Proto.Actor actor.
2. Import valid migrated state referencing version 2.
3. Resume the same actor after import completes.

Before this change, the runner receives version 1’s graph with version 2’s state. After this change, both reference version 2.

## Verification

Run the focused tests:

```sh
dotnet test test/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor.UnitTests/Elsa.Workflows.Runtime.ProtoActor.UnitTests.csproj
```

Build the runtime:

```sh
dotnet build src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Elsa.Workflows.Runtime.ProtoActor.csproj
```

Results:

- Original implementation: **3 failed, 1 passed**.
- Fixed implementation: **4 passed**.
- Runtime builds passed for **.NET 8, 9, and 10**, with existing warnings.

The tests exercise real actor message handling with mocked workflow services; they are not end-to-end alteration tests. The full solution test suite was not run.