### PR TITLE
fix(dapper): honor BeforeLastUpdated in the workflow instance store

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.Dapper/Extensions/ParameterizedQueryBuilderExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Extensions/ParameterizedQueryBuilderExtensions.cs
@@ -166,6 +166,22 @@ public static class ParameterizedQueryBuilderExtensions
     }
 
     /// <summary>
+    /// Appends an AND clause matching values strictly less than the specified value, if the value is not null.
+    /// </summary>
+    /// <param name="query">The query.</param>
+    /// <param name="field">The field.</param>
+    /// <param name="value">The value.</param>
+    public static ParameterizedQuery LessThan(this ParameterizedQuery query, string field, object? value)
+    {
+        if (value == null) return query;
+
+        query.Sql.AppendLine($"and {field} < @{field}");
+        query.Parameters.Add($"@{field}", value);
+
+        return query;
+    }
+
+    /// <summary>
     /// Appends a search term for workflow definitions to the search.
     /// </summary>
     /// <param name="query">The query.</param>

--- a/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
@@ -188,6 +188,7 @@ internal class DapperWorkflowInstanceStore(Store<WorkflowInstanceRecord> store, 
             .In(nameof(WorkflowInstance.Status), filter.WorkflowStatuses?.Select(x => x.ToString()))
             .In(nameof(WorkflowInstance.SubStatus), filter.WorkflowSubStatuses?.Select(x => x.ToString()))
             .Is(nameof(WorkflowInstance.IsExecuting), filter.IsExecuting)
+            .LessThan(nameof(WorkflowInstance.UpdatedAt), filter.BeforeLastUpdated)
             .AndWorkflowInstanceSearchTerm(filter.SearchTerm);
     }
 

--- a/test/modules/persistence/Elsa.Persistence.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
+++ b/test/modules/persistence/Elsa.Persistence.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
@@ -1,0 +1,148 @@
+using Dapper;
+using Elsa.Common.Multitenancy;
+using Elsa.Persistence.Dapper.Modules.Management.Records;
+using Elsa.Persistence.Dapper.Modules.Management.Stores;
+using Elsa.Persistence.Dapper.Services;
+using Elsa.Workflows;
+using Elsa.Workflows.Management.Filters;
+using Microsoft.Data.Sqlite;
+using NSubstitute;
+
+namespace Elsa.Persistence.Dapper.UnitTests;
+
+public sealed class DapperWorkflowInstanceStoreTests : IDisposable
+{
+    private static readonly DateTimeOffset Cutoff = new(2026, 1, 1, 12, 5, 0, TimeSpan.Zero);
+
+    private readonly string _databasePath = Path.Combine(Path.GetTempPath(), $"elsa-dapper-instances-{Guid.NewGuid():N}.db");
+    private readonly DapperWorkflowInstanceStore _store;
+    private readonly TestTenantAccessor _tenantAccessor = new();
+
+    public DapperWorkflowInstanceStoreTests()
+    {
+        var connectionString = new SqliteConnectionStringBuilder { DataSource = _databasePath, Pooling = false }.ToString();
+        var connectionProvider = new SqliteDbConnectionProvider(connectionString);
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        connection.Execute("""
+                           create table WorkflowInstances (
+                               Id text not null primary key,
+                               TenantId text null,
+                               DefinitionId text not null,
+                               DefinitionVersionId text not null,
+                               Version integer not null,
+                               WorkflowState text not null,
+                               Status text not null,
+                               SubStatus text not null,
+                               IsExecuting integer not null,
+                               CorrelationId text null,
+                               Name text null,
+                               IncidentCount integer not null,
+                               IsSystem integer not null,
+                               CreatedAt text not null,
+                               UpdatedAt text null,
+                               FinishedAt text null
+                           );
+                           """);
+
+        // Seeded through parameters rather than literals so the driver writes the timestamps in
+        // exactly the format it later binds them in for comparison.
+        Insert(connection, "stale-executing", Cutoff.AddMinutes(-5), isExecuting: true);
+        Insert(connection, "stale-idle", Cutoff.AddMinutes(-1), isExecuting: false);
+        Insert(connection, "at-cutoff", Cutoff, isExecuting: true);
+        Insert(connection, "fresh-executing", Cutoff.AddMinutes(4), isExecuting: true);
+
+        var store = new Store<WorkflowInstanceRecord>(connectionProvider, _tenantAccessor, "WorkflowInstances");
+        _store = new DapperWorkflowInstanceStore(store, Substitute.For<IWorkflowStateSerializer>());
+    }
+
+    [Fact]
+    public async Task FindManyIdsAsync_WithBeforeLastUpdated_ExcludesInstancesUpdatedAtOrAfterTheCutoff()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var ids = await _store.FindManyIdsAsync(new WorkflowInstanceFilter { BeforeLastUpdated = Cutoff });
+
+        Assert.Equal(["stale-executing", "stale-idle"], ids.Order());
+    }
+
+    /// <summary>
+    /// Mirrors the filter used by RestartInterruptedWorkflowsTask. An instance that is executing right
+    /// now must not be reported as interrupted, or it gets restarted from the beginning mid-flight.
+    /// </summary>
+    [Fact]
+    public async Task FindManyIdsAsync_WithBeforeLastUpdatedAndIsExecuting_ExcludesInstancesThatAreStillActive()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var ids = await _store.FindManyIdsAsync(new WorkflowInstanceFilter
+        {
+            IsExecuting = true,
+            BeforeLastUpdated = Cutoff
+        });
+
+        Assert.Equal(["stale-executing"], ids);
+    }
+
+    [Fact]
+    public async Task FindManyIdsAsync_WithoutBeforeLastUpdated_ReturnsAllInstances()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var ids = await _store.FindManyIdsAsync(new WorkflowInstanceFilter());
+
+        Assert.Equal(["at-cutoff", "fresh-executing", "stale-executing", "stale-idle"], ids.Order());
+    }
+
+    [Fact]
+    public async Task CountAsync_WithBeforeLastUpdated_CountsOnlyInstancesUpdatedBeforeTheCutoff()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var count = await _store.CountAsync(new WorkflowInstanceFilter { BeforeLastUpdated = Cutoff });
+
+        Assert.Equal(2, count);
+    }
+
+    public void Dispose()
+    {
+        File.Delete(_databasePath);
+    }
+
+    private static void Insert(SqliteConnection connection, string id, DateTimeOffset updatedAt, bool isExecuting)
+    {
+        connection.Execute(
+            """
+            insert into WorkflowInstances
+                (Id, TenantId, DefinitionId, DefinitionVersionId, Version, WorkflowState, Status, SubStatus, IsExecuting, IncidentCount, IsSystem, CreatedAt, UpdatedAt)
+            values
+                (@Id, 'tenant-a', 'definition-1', 'definition-1:1', 1, '{}', 'Running', 'Executing', @IsExecuting, 0, 0, @CreatedAt, @UpdatedAt);
+            """,
+            new
+            {
+                Id = id,
+                IsExecuting = isExecuting,
+                CreatedAt = updatedAt,
+                UpdatedAt = updatedAt
+            });
+    }
+
+    private sealed class TestTenantAccessor : ITenantAccessor
+    {
+        public string TenantId => Tenant?.Id ?? Elsa.Common.Multitenancy.Tenant.DefaultTenantId;
+        public Tenant? Tenant { get; private set; }
+
+        public IDisposable PushContext(Tenant? tenant)
+        {
+            var previousTenant = Tenant;
+            Tenant = tenant;
+            return new Restore(() => Tenant = previousTenant);
+        }
+
+        private sealed class Restore(Action restore) : IDisposable
+        {
+            public void Dispose() => restore();
+        }
+    }
+}

--- a/test/modules/persistence/Elsa.Persistence.Dapper.UnitTests/ParameterizedQueryBuilderExtensionsTests.cs
+++ b/test/modules/persistence/Elsa.Persistence.Dapper.UnitTests/ParameterizedQueryBuilderExtensionsTests.cs
@@ -96,6 +96,30 @@ public sealed class ParameterizedQueryBuilderExtensionsTests : IDisposable
         Assert.Equal(2, result.TotalCount);
     }
 
+    [Fact]
+    public async Task LessThan_WithValue_ExcludesRowsAtOrAboveTheValue()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var result = await FindManyAsync(query => query.LessThan(nameof(TestRecord.Value), "value-a2"));
+
+        Assert.Equal(["a1"], result.Items.Select(x => x.Id));
+        Assert.Equal(1, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task LessThan_WithNullValue_PreservesOtherFilters()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var result = await FindManyAsync(query => query
+            .Is(nameof(TestRecord.Value), "value-a2")
+            .LessThan(nameof(TestRecord.Id), null));
+
+        Assert.Equal(["a2"], result.Items.Select(x => x.Id));
+        Assert.Equal(1, result.TotalCount);
+    }
+
     public void Dispose()
     {
         File.Delete(_databasePath);


### PR DESCRIPTION
## Problem

`DapperWorkflowInstanceStore.ApplyFilter` does not implement `WorkflowInstanceFilter.BeforeLastUpdated`. The property is accepted and then silently dropped from the generated SQL, so the query returns unfiltered results with no error.

`RestartInterruptedWorkflowsTask` builds its filter as:

```csharp
new WorkflowInstanceFilter
{
    IsExecuting = true,
    BeforeLastUpdated = systemClock.UtcNow - options.Value.InactivityThreshold,
    WorkflowStatus = WorkflowStatus.Running
}
```

`BeforeLastUpdated` is the condition that distinguishes a genuinely interrupted workflow from one that is merely executing right now. Because the Dapper store drops it, the effective predicate becomes `IsExecuting = 1 AND Status = 'Running'`, so every workflow that happens to be mid-execution when the task ticks is treated as interrupted and restarted from the beginning.

The canonical `WorkflowInstanceFilter.Apply(IQueryable)` does honour it (`x.UpdatedAt < filter.BeforeLastUpdated`), so the EF Core and in-memory stores behave correctly. This is specific to the Dapper provider.

## Expected vs actual

**Expected:** only instances whose `UpdatedAt` is older than `InactivityThreshold` are considered interrupted.

**Actual:** on Dapper, any instance that is executing at the moment of the scan is restarted from its first activity.

## Impact

On a SQL Server backed deployment, 29 of 30 restarts over 7 days targeted instances between 66 ms and 272 ms old. For a workflow whose first activities are not idempotent this is destructive rather than merely wasteful: the restart discards the instance's state including pending bookmarks (in our case a multi-day `Delay`), so the workflow never resumes and the remainder of its sequence is silently lost.

## Root cause

`ParameterizedQuery` had no inequality support at all — only `Is`, `IsNot`, `IsNull`, `IsNotNull`, `In`, `NotIn` and `StartsWith`. Any filter property requiring `<` or `>` could not be expressed, so it was omitted rather than rejected.

## Change

- Add `ParameterizedQueryBuilderExtensions.LessThan`, following the existing `Is`/`IsNot` shape: null short-circuit, `@{field}` parameter naming. The SQL is emitted directly rather than through `ISqlDialect`, matching what `WorkflowDefinitionSearchTerm`, `AndWorkflowInstanceSearchTerm` and `StartsWith` already do, and avoiding a breaking change to that public interface. `<` is identical across SQLite, SQL Server and PostgreSQL, so there is no dialect variance to abstract.
- Apply `filter.BeforeLastUpdated` in `DapperWorkflowInstanceStore.ApplyFilter`.

Two source lines of behaviour change; the rest is tests.

## Steps to verify

```
dotnet test test/modules/persistence/Elsa.Persistence.Dapper.UnitTests
```

19 tests pass (13 before this change).

New coverage:

- `DapperWorkflowInstanceStoreTests` — 4 tests exercising the store against SQLite, including one that mirrors `RestartInterruptedWorkflowsTask`'s exact filter and asserts that an actively-executing instance is excluded.
- `ParameterizedQueryBuilderExtensionsTests` — 2 direct tests for `LessThan` covering the exclusive boundary and the null short-circuit.

Both failure directions were checked, not just the happy path:

- Reverting the `ApplyFilter` line fails 3 tests, while the "no filter set" control test stays green — confirming the tests detect the missing clause rather than over-constraining.
- Mutating `<` to `<=` fails 4 tests.

Timestamps in the store test are seeded through parameters rather than SQL literals so the value written and the value later bound for comparison use the same format. All offsets are UTC, since SQLite stores `DateTimeOffset` as text and mixed offsets would not sort chronologically.

## Out of scope

`TimestampFilters` is dropped by the same store for the same underlying reason. It needs date-range semantics and column-name normalisation, so it is better suited to a follow-up PR than bundled here.

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
