### PR TITLE
Fix MongoDB VariableSerializer dropping StorageDriverType (#8047)

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Features/MongoDbFeature.cs
@@ -5,6 +5,7 @@ using Elsa.Persistence.MongoDb.Contracts;
 using Elsa.Persistence.MongoDb.HostedServices;
 using Elsa.Persistence.MongoDb.NamingStrategies;
 using Elsa.Persistence.MongoDb.Options;
+using Elsa.Persistence.MongoDb.Serializers;
 using Elsa.Workflows.Activities.Flowchart.Models;
 using Elsa.Workflows.Runtime.Entities;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +52,7 @@ public class MongoDbFeature(IModule module) : FeatureBase(module)
 
         Services.TryAddScoped<DefaultNamingStrategy>();
         Services.AddScoped(CollectionNamingStrategy);
+        Services.TryAddSingleton<VariableSerializer>();
 
         RegisterClassMaps();
     }

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/HostedServices/ConfigureMongoDbSerializers.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/HostedServices/ConfigureMongoDbSerializers.cs
@@ -21,13 +21,13 @@ namespace Elsa.Persistence.MongoDb.HostedServices;
 /// It uses helper methods to register these serializers during the application's startup process.
 /// </remarks>
 [UsedImplicitly]
-public class ConfigureMongoDbSerializers(IPayloadSerializer payloadSerializer) : IHostedService
+public class ConfigureMongoDbSerializers(IPayloadSerializer payloadSerializer, VariableSerializer variableSerializer) : IHostedService
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
         TryRegisterSerializer(typeof(object), new PolymorphicSerializer());
         TryRegisterSerializer(typeof(Type), new TypeSerializer());
-        TryRegisterSerializer(typeof(Variable), new VariableSerializer());
+        TryRegisterSerializer(typeof(Variable), variableSerializer);
         TryRegisterSerializer(typeof(Version), new VersionSerializer());
         TryRegisterSerializer(typeof(JsonElement), new JsonElementSerializer());
         TryRegisterSerializer(typeof(JsonNode), new JsonNodeBsonConverter());

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Serializers/VariableSerializer.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Serializers/VariableSerializer.cs
@@ -2,6 +2,7 @@ using Elsa.Common.Serialization;
 using Elsa.Workflows;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -18,10 +19,11 @@ public class VariableSerializer : IBsonSerializer<Variable>
     /// <summary>
     /// Initializes a new instance of the <see cref="VariableSerializer"/> class.
     /// </summary>
-    public VariableSerializer()
+    /// <param name="serializationTypeRegistry">The DI-registered serialization type registry used to resolve storage drivers and variable types.</param>
+    /// <param name="logger">The logger used by <see cref="VariableMapper"/> when type resolution fails.</param>
+    public VariableSerializer(ISerializationTypeRegistry serializationTypeRegistry, ILogger<VariableMapper>? logger = null)
     {
-        var serializationTypeRegistry = SerializationTypeRegistry.CreateDefault();
-        _mapper = new VariableMapper(serializationTypeRegistry, NullLogger<VariableMapper>.Instance);
+        _mapper = new VariableMapper(serializationTypeRegistry, logger ?? NullLogger<VariableMapper>.Instance);
     }
     
     /// <inheritdoc />

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/VariableSerializerTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/VariableSerializerTests.cs
@@ -5,7 +5,6 @@ using Elsa.Workflows;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Services;
-using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -81,10 +80,9 @@ public class VariableSerializerTests
     private static ISerializationTypeRegistry CreateWorkflowsRegistry()
     {
         var options = new SerializationTypeOptions();
-        options.AddTypeAliasWithLegacyName<WorkflowStorageDriver>(nameof(WorkflowStorageDriver));
         options.AddTypeAliasWithLegacyName<WorkflowInstanceStorageDriver>(nameof(WorkflowInstanceStorageDriver));
         options.AddTypeAliasWithLegacyName<MemoryStorageDriver>(nameof(MemoryStorageDriver));
-        return new SerializationTypeRegistry(Options.Create(options));
+        return new SerializationTypeRegistry(Microsoft.Extensions.Options.Options.Create(options));
     }
 
     private static Variable<string> CreateDialogIdVariable() =>

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/VariableSerializerTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/VariableSerializerTests.cs
@@ -1,0 +1,112 @@
+using Elsa.Common.Serialization;
+using Elsa.Extensions;
+using Elsa.Persistence.MongoDb.Serializers;
+using Elsa.Workflows;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Services;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Elsa.MongoDb.UnitTests;
+
+public class VariableSerializerTests
+{
+    [Fact(DisplayName = "VariableSerializer preserves StorageDriverType when using the populated serialization type registry")]
+    public void Serialize_WithPopulatedRegistry_RoundTripsWorkflowInstanceStorageDriver()
+    {
+        var serializer = CreateSerializer(CreateWorkflowsRegistry());
+        var variable = CreateDialogIdVariable();
+
+        var restored = RoundTrip(serializer, variable);
+
+        Assert.Equal(variable.Id, restored.Id);
+        Assert.Equal(variable.Name, restored.Name);
+        Assert.Equal("abc", restored.Value);
+        Assert.Equal(typeof(WorkflowInstanceStorageDriver), restored.StorageDriverType);
+        Assert.IsType<Variable<string>>(restored);
+    }
+
+    [Fact(DisplayName = "VariableSerializer resolves the 3.7 storageDriverTypeName assembly-qualified name through the populated registry")]
+    public void Deserialize_WithLegacyWorkflowInstanceStorageDriverTypeName_RestoresStorageDriverType()
+    {
+        var serializer = CreateSerializer(CreateWorkflowsRegistry());
+        var legacyTypeName = typeof(WorkflowInstanceStorageDriver).GetSimpleAssemblyQualifiedName();
+        var model = new VariableModel("dialogIdVariable", "DialogId", "String", "abc", legacyTypeName);
+
+        var restored = DeserializeModel(serializer, model);
+
+        Assert.Equal(typeof(WorkflowInstanceStorageDriver), restored.StorageDriverType);
+        Assert.Equal("DialogId", restored.Name);
+        Assert.Equal("abc", restored.Value);
+    }
+
+    [Fact(DisplayName = "VariableSerializer loses StorageDriverType against an empty default registry (the 3.8.0 regression)")]
+    public void Serialize_WithEmptyDefaultRegistry_DropsStorageDriverType()
+    {
+        var serializer = CreateSerializer(SerializationTypeRegistry.CreateDefault());
+        var variable = CreateDialogIdVariable();
+
+        var restored = RoundTrip(serializer, variable);
+
+        Assert.Null(restored.StorageDriverType);
+    }
+
+    [Fact(DisplayName = "VariableSerializer serializes null variables as BSON null")]
+    public void Serialize_NullVariable_RoundTripsAsNull()
+    {
+        var serializer = CreateSerializer(CreateWorkflowsRegistry());
+
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+        {
+            writer.WriteStartDocument();
+            writer.WriteName("value");
+            serializer.Serialize(BsonSerializationContext.CreateRoot(writer), null!);
+            writer.WriteEndDocument();
+        }
+
+        using var reader = new BsonDocumentReader(document);
+        reader.ReadStartDocument();
+        reader.ReadName("value");
+        var restored = serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+
+        Assert.Null(restored);
+    }
+
+    private static VariableSerializer CreateSerializer(ISerializationTypeRegistry registry) => new(registry);
+
+    private static ISerializationTypeRegistry CreateWorkflowsRegistry()
+    {
+        var options = new SerializationTypeOptions();
+        options.AddTypeAliasWithLegacyName<WorkflowStorageDriver>(nameof(WorkflowStorageDriver));
+        options.AddTypeAliasWithLegacyName<WorkflowInstanceStorageDriver>(nameof(WorkflowInstanceStorageDriver));
+        options.AddTypeAliasWithLegacyName<MemoryStorageDriver>(nameof(MemoryStorageDriver));
+        return new SerializationTypeRegistry(Options.Create(options));
+    }
+
+    private static Variable<string> CreateDialogIdVariable() =>
+        new("DialogId", "abc", "dialogIdVariable")
+        {
+            StorageDriverType = typeof(WorkflowInstanceStorageDriver)
+        };
+
+    private static Variable RoundTrip(VariableSerializer serializer, Variable variable)
+    {
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+            serializer.Serialize(BsonSerializationContext.CreateRoot(writer), variable);
+
+        using var reader = new BsonDocumentReader(document);
+        return serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+    }
+
+    private static Variable DeserializeModel(VariableSerializer serializer, VariableModel model)
+    {
+        var document = model.ToBsonDocument();
+        using var reader = new BsonDocumentReader(document);
+        return serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/elsa-workflows/elsa-core/issues/8047

## Problem

After upgrading Elsa from 3.7.x to 3.8.0 with `Elsa.Persistence.MongoDb`, workflow variables are no longer persisted into workflow state. On resume (event, timer, child workflow completion, delay), variables deserialize as `null` and activities that re-evaluate input expressions crash.

## Root cause

`VariableSerializer` constructed `VariableMapper` against `SerializationTypeRegistry.CreateDefault()`, which is an **isolated, empty** registry — not the DI-registered `ISerializationTypeRegistry` that Elsa features populate from `IOptions<SerializationTypeOptions>`.

In 3.8, `SerializationTypeResolver` no longer falls back to unrestricted `Type.GetType`. Storage driver type names such as `Elsa.Workflows.WorkflowInstanceStorageDriver, Elsa.Workflows.Core` therefore fail to resolve, `StorageDriverType` is set to `null`, and variables are silently not persisted.

`ConfigureMongoDbSerializers` compounded this by always doing `new VariableSerializer()` with the parameterless ctor.

## Fix

- `VariableSerializer` now requires the DI-registered `ISerializationTypeRegistry`.
- `MongoDbFeature` registers `VariableSerializer` as a singleton (`TryAddSingleton`), so it can be substituted before host start (helpful with MongoDB driver 3.x, where `RegisterSerializer` throws if a different serializer is already registered).
- `ConfigureMongoDbSerializers` injects that serializer instead of constructing an empty-registry instance.

Scope is limited to VariableSerializer / variable persistence. This does **not** address #8048 (`JsonNodeBsonConverter`).

## Tests

Adds BSON round-trip tests that:

- preserve `WorkflowInstanceStorageDriver` when using a populated registry
- restore the 3.7 `storageDriverTypeName` assembly-qualified name through the populated registry
- document that an empty default registry still drops `StorageDriverType` (the 3.8.0 regression)

Local verification: `dotnet test test/modules/persistence/Elsa.MongoDb.UnitTests/Elsa.MongoDb.UnitTests.csproj -f net10.0` — 5 passed (4 new + existing `MongoKeyValueStoreTests`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f6c2ea2-a656-5f8a-9898-11595935276f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f6c2ea2-a656-5f8a-9898-11595935276f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

