### PR TITLE
Fix MongoDB JsonObject/JsonArray/JsonValue serialization (#8048)

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.MongoDb/HostedServices/ConfigureMongoDbSerializers.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/HostedServices/ConfigureMongoDbSerializers.cs
@@ -17,7 +17,8 @@ namespace Elsa.Persistence.MongoDb.HostedServices;
 /// <remarks>
 /// This class implements <see cref="IHostedService"/> and is responsible for registering serializers to handle
 /// specific types such as <see cref="object"/>, <see cref="Type"/>, <see cref="Variable"/>, <see cref="Version"/>,
-/// <see cref="JsonElement"/>, <see cref="JsonNode"/>, and <see cref="FlowScope"/>.
+/// <see cref="JsonElement"/>, <see cref="JsonNode"/> (including <see cref="JsonObject"/>, <see cref="JsonArray"/>,
+/// and <see cref="JsonValue"/>), and <see cref="FlowScope"/>.
 /// It uses helper methods to register these serializers during the application's startup process.
 /// </remarks>
 [UsedImplicitly]
@@ -30,7 +31,7 @@ public class ConfigureMongoDbSerializers(IPayloadSerializer payloadSerializer, V
         TryRegisterSerializer(typeof(Variable), variableSerializer);
         TryRegisterSerializer(typeof(Version), new VersionSerializer());
         TryRegisterSerializer(typeof(JsonElement), new JsonElementSerializer());
-        TryRegisterSerializer(typeof(JsonNode), new JsonNodeBsonConverter());
+        JsonNodeBsonConverter.RegisterSerializers();
         TryRegisterSerializer(typeof(FlowScope), new FlowScopeSerializer(payloadSerializer));
 
         return Task.CompletedTask;

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Serializers/JsonNodeBsonSerializer.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Serializers/JsonNodeBsonSerializer.cs
@@ -159,10 +159,18 @@ public class JsonNodeBsonConverter<TNode> : IBsonSerializer<TNode> where TNode :
 
     private static bool IsTaggedJsonNode(BsonDocument document)
     {
-        if (!document.Contains("type") || !document.Contains("value") || document["type"].BsonType != BsonType.String)
+        if (document.ElementCount != 2 || !document.Contains("type") || !document.Contains("value"))
             return false;
 
-        return document["type"].AsString is "JsonObject" or "JsonArray" or "JsonValue";
+        if (document["type"].BsonType != BsonType.String)
+            return false;
+
+        return document["type"].AsString switch
+        {
+            "JsonObject" or "JsonArray" => document["value"].BsonType == BsonType.String,
+            "JsonValue" => true,
+            _ => false
+        };
     }
 
     private static JsonNode DeserializeTagged(BsonDocument document)

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Serializers/JsonNodeBsonSerializer.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Serializers/JsonNodeBsonSerializer.cs
@@ -2,19 +2,77 @@ using System.Text.Json.Nodes;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using static MongoDB.Bson.Serialization.BsonSerializer;
 
 namespace Elsa.Persistence.MongoDb.Serializers;
 
 /// <summary>
 /// Serializes a <see cref="JsonNode"/>.
 /// </summary>
-public class JsonNodeBsonConverter : IBsonSerializer<JsonNode>
+public class JsonNodeBsonConverter : JsonNodeBsonConverter<JsonNode>
+{
+    private static int _providerRegistered;
+
+    /// <summary>
+    /// Registers serializers for <see cref="JsonNode"/> and the concrete types
+    /// <see cref="JsonObject"/>, <see cref="JsonArray"/>, and <see cref="JsonValue"/>.
+    /// Also registers a serialization provider so internal <see cref="JsonValue"/>
+    /// implementations are looked up without falling back to a class map.
+    /// </summary>
+    public static void RegisterSerializers()
+    {
+        if (Interlocked.CompareExchange(ref _providerRegistered, 1, 0) == 0)
+            RegisterSerializationProvider(new JsonNodeBsonSerializationProvider());
+
+        TryRegisterSerializer(typeof(JsonNode), new JsonNodeBsonConverter());
+        TryRegisterSerializer(typeof(JsonObject), new JsonNodeBsonConverter<JsonObject>());
+        TryRegisterSerializer(typeof(JsonArray), new JsonNodeBsonConverter<JsonArray>());
+        TryRegisterSerializer(typeof(JsonValue), new JsonNodeBsonConverter<JsonValue>());
+    }
+}
+
+/// <summary>
+/// Serializes a <see cref="JsonNode"/> of the specified nominal type.
+/// <see cref="ValueType"/> must match the registered type so
+/// <c>BsonSerializer.LookupSerializer</c> (used by <see cref="PolymorphicSerializer"/>)
+/// finds this converter for <see cref="JsonObject"/>, <see cref="JsonArray"/>, and <see cref="JsonValue"/>.
+/// </summary>
+public class JsonNodeBsonConverter<TNode> : IBsonSerializer<TNode> where TNode : JsonNode
 {
     /// <inheritdoc />
-    public Type ValueType => typeof(JsonNode);
+    public Type ValueType => typeof(TNode);
 
     /// <inheritdoc />
-    public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, JsonNode value)
+    public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, TNode value)
+    {
+        SerializeJsonNode(context, value);
+    }
+
+    /// <inheritdoc />
+    public TNode Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var node = DeserializeJsonNode(context);
+        if (node is null)
+            return null!;
+        if (node is TNode typed)
+            return typed;
+
+        throw new BsonSerializationException($"Deserialized JsonNode of type '{node.GetType().FullName}' is not assignable to '{typeof(TNode).FullName}'.");
+    }
+
+    /// <inheritdoc />
+    public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
+    {
+        SerializeJsonNode(context, (JsonNode)value);
+    }
+
+    object IBsonSerializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        return DeserializeJsonNode(context)!;
+    }
+
+    private static void SerializeJsonNode(BsonSerializationContext context, JsonNode value)
     {
         if (value == null!)
         {
@@ -67,69 +125,132 @@ public class JsonNodeBsonConverter : IBsonSerializer<JsonNode>
         context.Writer.WriteEndDocument();
     }
 
-    public JsonNode Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    private static JsonNode? DeserializeJsonNode(BsonDeserializationContext context)
     {
-        context.Reader.ReadStartDocument();
-        var type = context.Reader.ReadString();
-        context.Reader.ReadName(Utf8NameDecoder.Instance);
+        var reader = context.Reader;
+        var bsonType = reader.GetCurrentBsonType();
 
-        JsonNode result;
+        switch (bsonType)
+        {
+            case BsonType.Null:
+                reader.ReadNull();
+                return null;
+            case BsonType.Document:
+                return DeserializeDocument(BsonDocumentSerializer.Instance.Deserialize(context));
+            case BsonType.Array:
+                return DeserializeLegacyArray(BsonArraySerializer.Instance.Deserialize(context));
+            default:
+                return DeserializePrimitiveJsonValue(ReadPrimitive(reader, bsonType));
+        }
+    }
+
+    private static JsonNode DeserializeDocument(BsonDocument document)
+    {
+        if (IsTaggedJsonNode(document))
+            return DeserializeTagged(document);
+
+        // Legacy class-map / dictionary format written when only JsonNode was registered:
+        // { "DialogId": { "type": "JsonValue", "value": "..." }, ... }
+        var obj = new JsonObject();
+        foreach (var element in document)
+            obj[element.Name] = DeserializeBsonValue(element.Value);
+        return obj;
+    }
+
+    private static bool IsTaggedJsonNode(BsonDocument document)
+    {
+        if (!document.Contains("type") || !document.Contains("value") || document["type"].BsonType != BsonType.String)
+            return false;
+
+        return document["type"].AsString is "JsonObject" or "JsonArray" or "JsonValue";
+    }
+
+    private static JsonNode DeserializeTagged(BsonDocument document)
+    {
+        var type = document["type"].AsString;
+        var value = document["value"];
+
         switch (type)
         {
             case "JsonObject":
-                var jsonObjectString = context.Reader.ReadString();
-                result = JsonNode.Parse(jsonObjectString);
-                break;
-
             case "JsonArray":
-                var jsonArrayString = context.Reader.ReadString();
-                result = JsonNode.Parse(jsonArrayString);
-                break;
-
+                return JsonNode.Parse(value.AsString)!;
             case "JsonValue":
-                var bsonType = context.Reader.GetCurrentBsonType();
-                switch (bsonType)
-                {
-                    case BsonType.String:
-                        result = JsonValue.Create(context.Reader.ReadString());
-                        break;
-                    case BsonType.Int32:
-                        result = JsonValue.Create(context.Reader.ReadInt32());
-                        break;
-                    case BsonType.Int64:
-                        result = JsonValue.Create(context.Reader.ReadInt64());
-                        break;
-                    case BsonType.Double:
-                        result = JsonValue.Create(context.Reader.ReadDouble());
-                        break;
-                    case BsonType.Boolean:
-                        result = JsonValue.Create(context.Reader.ReadBoolean());
-                        break;
-                    case BsonType.DateTime:
-                        result = JsonValue.Create(context.Reader.ReadDateTime());
-                        break;
-                    default:
-                        throw new BsonSerializationException($"Unsupported BSON type: {bsonType}");
-                }
-                break;
-
+                return DeserializePrimitiveJsonValue(value);
             default:
                 throw new BsonSerializationException($"Unsupported JsonNode type: {type}");
         }
-
-        context.Reader.ReadEndDocument();
-        return result!;
     }
 
-    /// <inheritdoc />
-    public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
+    private static JsonNode? DeserializeBsonValue(BsonValue value)
     {
-        Serialize(context, args, (JsonNode)value);
+        return value.BsonType switch
+        {
+            BsonType.Null => null,
+            BsonType.Document => DeserializeDocument(value.AsBsonDocument),
+            BsonType.Array => DeserializeLegacyArray(value.AsBsonArray),
+            _ => DeserializePrimitiveJsonValue(value)
+        };
     }
 
-    object IBsonSerializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    private static JsonArray DeserializeLegacyArray(BsonArray array)
     {
-        return Deserialize(context, args);
+        var result = new JsonArray();
+        foreach (var item in array)
+            result.Add(DeserializeBsonValue(item));
+        return result;
+    }
+
+    private static JsonValue DeserializePrimitiveJsonValue(BsonValue value)
+    {
+        switch (value.BsonType)
+        {
+            case BsonType.String:
+                return JsonValue.Create(value.AsString)!;
+            case BsonType.Int32:
+                return JsonValue.Create(value.AsInt32)!;
+            case BsonType.Int64:
+                return JsonValue.Create(value.AsInt64)!;
+            case BsonType.Double:
+                return JsonValue.Create(value.AsDouble)!;
+            case BsonType.Boolean:
+                return JsonValue.Create(value.AsBoolean)!;
+            case BsonType.DateTime:
+                return JsonValue.Create(value.AsBsonDateTime.MillisecondsSinceEpoch)!;
+            default:
+                throw new BsonSerializationException($"Unsupported BSON type: {value.BsonType}");
+        }
+    }
+
+    private static BsonValue ReadPrimitive(IBsonReader reader, BsonType bsonType)
+    {
+        return bsonType switch
+        {
+            BsonType.String => reader.ReadString(),
+            BsonType.Int32 => reader.ReadInt32(),
+            BsonType.Int64 => reader.ReadInt64(),
+            BsonType.Double => reader.ReadDouble(),
+            BsonType.Boolean => reader.ReadBoolean(),
+            BsonType.DateTime => new BsonDateTime(reader.ReadDateTime()),
+            _ => throw new BsonSerializationException($"Unsupported BSON type: {bsonType}")
+        };
     }
 }
 
+/// <summary>
+/// Provides <see cref="JsonNodeBsonConverter{TNode}"/> for any <see cref="JsonNode"/> subclass,
+/// including internal <see cref="JsonValue"/> implementations whose runtime type is not
+/// <see cref="JsonValue"/> itself.
+/// </summary>
+public class JsonNodeBsonSerializationProvider : IBsonSerializationProvider
+{
+    /// <inheritdoc />
+    public IBsonSerializer? GetSerializer(Type type)
+    {
+        if (type is null || !typeof(JsonNode).IsAssignableFrom(type))
+            return null;
+
+        var serializerType = typeof(JsonNodeBsonConverter<>).MakeGenericType(type);
+        return (IBsonSerializer)Activator.CreateInstance(serializerType)!;
+    }
+}

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/JsonNodeBsonConverterTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/JsonNodeBsonConverterTests.cs
@@ -195,6 +195,36 @@ public class JsonNodeBsonConverterTests
         Assert.Equal(3, obj["Count"]!.GetValue<int>());
     }
 
+    [Fact(DisplayName = "A type/value document that is not a two-field string envelope deserializes as a map")]
+    public void Deserialize_AmbiguousTypeValueDocument_IsMapNotEnvelope()
+    {
+        // {"type":"JsonObject","value":"{\"a\":1}"} with ElementCount == 2 and a BSON string
+        // value is a valid tagged envelope (covered by the round-trip tests). The false-positive
+        // risk is a class-map / user document that merely has type/value keys:
+        // extra elements, or value as a nested BSON document instead of a JSON string.
+        var extraElements = new BsonDocument
+        {
+            { "type", "JsonObject" },
+            { "value", """{"a":1}""" },
+            { "DialogId", "abc" }
+        };
+        var nestedDocumentValue = new BsonDocument
+        {
+            { "type", "JsonObject" },
+            { "value", new BsonDocument { { "a", 1 } } }
+        };
+        var serializer = new JsonNodeBsonConverter<JsonObject>();
+
+        var withExtra = DeserializeDocument(serializer, extraElements);
+        Assert.Equal("JsonObject", withExtra["type"]!.GetValue<string>());
+        Assert.Equal("""{"a":1}""", withExtra["value"]!.GetValue<string>());
+        Assert.Equal("abc", withExtra["DialogId"]!.GetValue<string>());
+
+        var withNestedValue = DeserializeDocument(serializer, nestedDocumentValue);
+        Assert.Equal("JsonObject", withNestedValue["type"]!.GetValue<string>());
+        Assert.Equal(1, withNestedValue["value"]!["a"]!.GetValue<int>());
+    }
+
     [Fact(DisplayName = "LookupSerializer returns the JsonNode converter for JsonObject, JsonArray, and JsonValue")]
     public void LookupSerializer_ConcreteJsonNodeTypes_UseJsonNodeConverter()
     {
@@ -208,6 +238,12 @@ public class JsonNodeBsonConverterTests
     {
         var restored = RoundTrip(new JsonNodeBsonConverter<JsonValue>(), original);
         Assert.Equal(original.ToJsonString(), restored.ToJsonString());
+    }
+
+    private static T DeserializeDocument<T>(IBsonSerializer<T> serializer, BsonDocument document)
+    {
+        using var reader = new BsonDocumentReader(document);
+        return serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
     }
 
     private static T RoundTrip<T>(IBsonSerializer<T> serializer, T value) where T : JsonNode

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/JsonNodeBsonConverterTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/JsonNodeBsonConverterTests.cs
@@ -1,0 +1,232 @@
+using System.Text.Json.Nodes;
+using Elsa.Extensions;
+using Elsa.Persistence.MongoDb.Serializers;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Elsa.MongoDb.UnitTests;
+
+public class JsonNodeBsonConverterTests
+{
+    static JsonNodeBsonConverterTests()
+    {
+        JsonNodeBsonConverter.RegisterSerializers();
+    }
+
+    [Fact(DisplayName = "JsonObject round-trips through the tagged BSON format")]
+    public void JsonObject_RoundTrips_ThroughTaggedFormat()
+    {
+        var original = JsonNode.Parse("""{"DialogId":"abc","Count":42,"Nested":{"Ok":true}}""")!.AsObject();
+        var serializer = new JsonNodeBsonConverter<JsonObject>();
+
+        var restored = RoundTrip(serializer, original);
+
+        Assert.Equal("abc", restored["DialogId"]!.GetValue<string>());
+        Assert.Equal(42, restored["Count"]!.GetValue<int>());
+        Assert.True(restored["Nested"]!["Ok"]!.GetValue<bool>());
+    }
+
+    [Fact(DisplayName = "JsonArray round-trips through the tagged BSON format")]
+    public void JsonArray_RoundTrips_ThroughTaggedFormat()
+    {
+        var original = JsonNode.Parse("""["a",1,true,{"k":"v"}]""")!.AsArray();
+        var serializer = new JsonNodeBsonConverter<JsonArray>();
+
+        var restored = RoundTrip(serializer, original);
+
+        Assert.Equal(4, restored.Count);
+        Assert.Equal("a", restored[0]!.GetValue<string>());
+        Assert.Equal(1, restored[1]!.GetValue<int>());
+        Assert.True(restored[2]!.GetValue<bool>());
+        Assert.Equal("v", restored[3]!["k"]!.GetValue<string>());
+    }
+
+    [Fact(DisplayName = "JsonValue string round-trips through the tagged BSON format")]
+    public void JsonValue_String_RoundTrips_ThroughTaggedFormat() =>
+        AssertJsonValueRoundTrip(JsonValue.Create("hello")!);
+
+    [Fact(DisplayName = "JsonValue int round-trips through the tagged BSON format")]
+    public void JsonValue_Int_RoundTrips_ThroughTaggedFormat() =>
+        AssertJsonValueRoundTrip(JsonValue.Create(42)!);
+
+    [Fact(DisplayName = "JsonValue bool round-trips through the tagged BSON format")]
+    public void JsonValue_Bool_RoundTrips_ThroughTaggedFormat() =>
+        AssertJsonValueRoundTrip(JsonValue.Create(true)!);
+
+    [Fact(DisplayName = "JsonValue double round-trips through the tagged BSON format")]
+    public void JsonValue_Double_RoundTrips_ThroughTaggedFormat() =>
+        AssertJsonValueRoundTrip(JsonValue.Create(1.5)!);
+
+    [Fact(DisplayName = "JsonNode serializer round-trips a JsonObject")]
+    public void JsonNode_RoundTrips_JsonObject()
+    {
+        var original = JsonNode.Parse("""{"payload":{"DialogId":"xyz"}}""")!;
+        var serializer = new JsonNodeBsonConverter();
+
+        var restored = RoundTrip(serializer, original);
+
+        Assert.IsType<JsonObject>(restored);
+        Assert.Equal("xyz", restored["payload"]!["DialogId"]!.GetValue<string>());
+    }
+
+    [Fact(DisplayName = "Null JsonNode serializes as BSON null")]
+    public void NullJsonNode_RoundTripsAsNull()
+    {
+        var serializer = new JsonNodeBsonConverter();
+        var document = new BsonDocument();
+
+        using (var writer = new BsonDocumentWriter(document))
+        {
+            writer.WriteStartDocument();
+            writer.WriteName("value");
+            serializer.Serialize(BsonSerializationContext.CreateRoot(writer), null!);
+            writer.WriteEndDocument();
+        }
+
+        using var reader = new BsonDocumentReader(document);
+        reader.ReadStartDocument();
+        reader.ReadName("value");
+        var restored = serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+
+        Assert.Null(restored);
+    }
+
+    [Fact(DisplayName = "Legacy class-map JsonObject document deserializes without a parameterless constructor")]
+    public void Deserialize_LegacyMapFormat_RestoresJsonObject()
+    {
+        var legacy = new BsonDocument
+        {
+            { "DialogId", new BsonDocument { { "type", "JsonValue" }, { "value", "abc" } } },
+            { "Count", new BsonDocument { { "type", "JsonValue" }, { "value", 7 } } },
+            { "Nested", new BsonDocument { { "type", "JsonObject" }, { "value", """{"Ok":true}""" } } }
+        };
+        var serializer = new JsonNodeBsonConverter<JsonObject>();
+
+        using var reader = new BsonDocumentReader(legacy);
+        var restored = serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+
+        Assert.Equal("abc", restored["DialogId"]!.GetValue<string>());
+        Assert.Equal(7, restored["Count"]!.GetValue<int>());
+        Assert.True(restored["Nested"]!["Ok"]!.GetValue<bool>());
+    }
+
+    [Fact(DisplayName = "Legacy class-map JsonArray document deserializes")]
+    public void Deserialize_LegacyArrayFormat_RestoresJsonArray()
+    {
+        var legacy = new BsonArray
+        {
+            new BsonDocument { { "type", "JsonValue" }, { "value", "a" } },
+            new BsonDocument { { "type", "JsonValue" }, { "value", 1 } }
+        };
+        var serializer = new JsonNodeBsonConverter<JsonArray>();
+        var document = new BsonDocument { { "value", legacy } };
+
+        using var reader = new BsonDocumentReader(document);
+        reader.ReadStartDocument();
+        reader.ReadName("value");
+        var restored = serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+
+        Assert.Equal(2, restored.Count);
+        Assert.Equal("a", restored[0]!.GetValue<string>());
+        Assert.Equal(1, restored[1]!.GetValue<int>());
+    }
+
+    [Fact(DisplayName = "PolymorphicSerializer round-trips JsonObject without the parameterless-constructor failure")]
+    public void PolymorphicSerializer_JsonObject_RoundTrips()
+    {
+        var original = JsonNode.Parse("""{"DialogId":"abc","Enabled":true}""")!.AsObject();
+        var serializer = new PolymorphicSerializer();
+
+        var restored = RoundTripObject(serializer, original);
+
+        var obj = Assert.IsType<JsonObject>(restored);
+        Assert.Equal("abc", obj["DialogId"]!.GetValue<string>());
+        Assert.True(obj["Enabled"]!.GetValue<bool>());
+    }
+
+    [Fact(DisplayName = "PolymorphicSerializer round-trips JsonArray")]
+    public void PolymorphicSerializer_JsonArray_RoundTrips()
+    {
+        var original = JsonNode.Parse("""[1,"x"]""")!.AsArray();
+        var serializer = new PolymorphicSerializer();
+
+        var restored = RoundTripObject(serializer, original);
+
+        var array = Assert.IsType<JsonArray>(restored);
+        Assert.Equal(1, array[0]!.GetValue<int>());
+        Assert.Equal("x", array[1]!.GetValue<string>());
+    }
+
+    [Fact(DisplayName = "PolymorphicSerializer round-trips JsonValue")]
+    public void PolymorphicSerializer_JsonValue_RoundTrips()
+    {
+        var original = JsonValue.Create("hello")!;
+        var serializer = new PolymorphicSerializer();
+
+        var restored = RoundTripObject(serializer, original);
+
+        var value = Assert.IsAssignableFrom<JsonValue>(restored);
+        Assert.Equal("hello", value.GetValue<string>());
+    }
+
+    [Fact(DisplayName = "PolymorphicSerializer deserializes a pre-fix JsonObject written in the legacy map format")]
+    public void PolymorphicSerializer_DeserializesLegacyJsonObjectMap()
+    {
+        var typeName = typeof(JsonObject).GetSimpleAssemblyQualifiedName();
+        var document = new BsonDocument
+        {
+            { "$type", typeName },
+            {
+                "$value", new BsonDocument
+                {
+                    { "DialogId", new BsonDocument { { "type", "JsonValue" }, { "value", "from-legacy" } } },
+                    { "Count", new BsonDocument { { "type", "JsonValue" }, { "value", 3 } } }
+                }
+            }
+        };
+        var serializer = new PolymorphicSerializer();
+
+        using var reader = new BsonDocumentReader(document);
+        var restored = serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+
+        var obj = Assert.IsType<JsonObject>(restored);
+        Assert.Equal("from-legacy", obj["DialogId"]!.GetValue<string>());
+        Assert.Equal(3, obj["Count"]!.GetValue<int>());
+    }
+
+    [Fact(DisplayName = "LookupSerializer returns the JsonNode converter for JsonObject, JsonArray, and JsonValue")]
+    public void LookupSerializer_ConcreteJsonNodeTypes_UseJsonNodeConverter()
+    {
+        Assert.IsAssignableFrom<JsonNodeBsonConverter<JsonObject>>(BsonSerializer.LookupSerializer(typeof(JsonObject)));
+        Assert.IsAssignableFrom<JsonNodeBsonConverter<JsonArray>>(BsonSerializer.LookupSerializer(typeof(JsonArray)));
+        Assert.IsAssignableFrom<JsonNodeBsonConverter<JsonValue>>(BsonSerializer.LookupSerializer(typeof(JsonValue)));
+        Assert.IsAssignableFrom<JsonNodeBsonConverter>(BsonSerializer.LookupSerializer(typeof(JsonNode)));
+    }
+
+    private static void AssertJsonValueRoundTrip(JsonValue original)
+    {
+        var restored = RoundTrip(new JsonNodeBsonConverter<JsonValue>(), original);
+        Assert.Equal(original.ToJsonString(), restored.ToJsonString());
+    }
+
+    private static T RoundTrip<T>(IBsonSerializer<T> serializer, T value) where T : JsonNode
+    {
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+            serializer.Serialize(BsonSerializationContext.CreateRoot(writer), value);
+
+        using var reader = new BsonDocumentReader(document);
+        return serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+    }
+
+    private static object RoundTripObject(PolymorphicSerializer serializer, object value)
+    {
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+            serializer.Serialize(BsonSerializationContext.CreateRoot(writer), value);
+
+        using var reader = new BsonDocumentReader(document);
+        return serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/elsa-workflows/elsa-core/issues/8048

Rebased onto `release/3.8.0` after #185 (`b645a1c`) so this branch includes the VariableSerializer DI wiring and has no conflict with that merge. Scope remains JsonNode serialization only.

## Problem

`ConfigureMongoDbSerializers` registered `JsonNodeBsonConverter` only for the base `System.Text.Json.Nodes.JsonNode` type. `PolymorphicSerializer` (used for `object`-typed workflow-state members) looks up serializers by the **concrete runtime type** (`JsonObject`, `JsonArray`, `JsonValue`).

When a JS object literal ends up in persisted state (common: `DispatchWorkflow` input with `WaitForCompletion`), serialize "succeeds" via MongoDB's class-map/dictionary fallback, but deserialize fails:

```
System.FormatException: Cannot dynamically create an instance of type
'System.Text.Json.Nodes.JsonObject'. Reason: No parameterless constructor defined.
```

The workflow instance then cannot be read on resume.

## Fix

- Register `JsonNodeBsonConverter<T>` for `JsonNode`, `JsonObject`, `JsonArray`, and `JsonValue` so `LookupSerializer` finds it for the types `PolymorphicSerializer` actually asks for.
- Register an `IBsonSerializationProvider` for other `JsonNode` subclasses (internal `JsonValue` implementations).
- Accept documents already written in the legacy class-map "map" format (`{ "DialogId": { "type": "JsonValue", "value": "..." }, ... }`) so pre-fix suspended instances can still be read.
- New writes keep the existing tagged format (`{ "type": "JsonObject", "value": "<json string>" }`).
- Tagged-envelope detection requires exactly two elements (`type` + `value`). For `JsonObject`/`JsonArray`, `value` must be a BSON string so a document that merely has those keys is treated as a map.

Does **not** redo `VariableSerializer` / #8047. That wiring comes from #185 (`variableSerializer` injection + `TryAddSingleton<VariableSerializer>()`). This PR only replaces the `JsonNode` registration line with `JsonNodeBsonConverter.RegisterSerializers()`.

## Tests

Adds BSON tests that:

- round-trip `JsonObject`, `JsonArray`, and `JsonValue` through the tagged format
- deserialize the legacy map/array formats
- round-trip those types through `PolymorphicSerializer` (the reported failure path)
- deserialize a pre-fix `{$type: JsonObject, $value: <map>}` document
- treat ambiguous `type`/`value` documents (extra elements, or `value` as a nested BSON document) as maps, not envelopes

Verified locally after review fixes: `dotnet test test/modules/persistence/Elsa.MongoDb.UnitTests/Elsa.MongoDb.UnitTests.csproj` on `eff72480134e15bf19d774b146d6ebdeadb87743` — **21 passed**, 0 failed, 0 skipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed2a3991-7dc6-579d-a964-89f869b933a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed2a3991-7dc6-579d-a964-89f869b933a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

