### PR TITLE
fix(dapper): honor BeforeLastUpdated in the workflow instance store

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.Dapper/Elsa.Persistence.Dapper.csproj
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Elsa.Persistence.Dapper.csproj
@@ -12,6 +12,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Elsa.Dapper.UnitTests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Azure.Identity"/>
         <PackageReference Include="Dapper"/>
         <PackageReference Include="FluentMigrator"/>

--- a/src/modules/persistence/Elsa.Persistence.Dapper/Extensions/ParameterizedQueryBuilderExtensions.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Extensions/ParameterizedQueryBuilderExtensions.cs
@@ -166,6 +166,22 @@ public static class ParameterizedQueryBuilderExtensions
     }
 
     /// <summary>
+    /// Appends an AND clause matching values strictly less than the specified value, if the value is not null.
+    /// </summary>
+    /// <param name="query">The query.</param>
+    /// <param name="field">The field.</param>
+    /// <param name="value">The value.</param>
+    public static ParameterizedQuery LessThan(this ParameterizedQuery query, string field, object? value)
+    {
+        if (value == null) return query;
+
+        query.Sql.AppendLine($"and {field} < @{field}");
+        query.Parameters.Add($"@{field}", value);
+
+        return query;
+    }
+
+    /// <summary>
     /// Appends a search term for workflow definitions to the search.
     /// </summary>
     /// <param name="query">The query.</param>

--- a/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
@@ -209,6 +209,7 @@ internal class DapperWorkflowInstanceStore(Store<WorkflowInstanceRecord> store, 
             .In(nameof(WorkflowInstance.Status), filter.WorkflowStatuses?.Select(x => x.ToString()))
             .In(nameof(WorkflowInstance.SubStatus), filter.WorkflowSubStatuses?.Select(x => x.ToString()))
             .Is(nameof(WorkflowInstance.IsExecuting), filter.IsExecuting)
+            .LessThan(nameof(WorkflowInstance.UpdatedAt), filter.BeforeLastUpdated)
             .AndWorkflowInstanceSearchTerm(filter.SearchTerm);
     }
 

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
@@ -1,0 +1,148 @@
+using Dapper;
+using Elsa.Common.Multitenancy;
+using Elsa.Persistence.Dapper.Modules.Management.Records;
+using Elsa.Persistence.Dapper.Modules.Management.Stores;
+using Elsa.Persistence.Dapper.Services;
+using Elsa.Workflows;
+using Elsa.Workflows.Management.Filters;
+using Microsoft.Data.Sqlite;
+using NSubstitute;
+
+namespace Elsa.Dapper.UnitTests;
+
+public sealed class DapperWorkflowInstanceStoreTests : IDisposable
+{
+    private static readonly DateTimeOffset Cutoff = new(2026, 1, 1, 12, 5, 0, TimeSpan.Zero);
+
+    private readonly string _databasePath = Path.Combine(Path.GetTempPath(), $"elsa-dapper-instances-{Guid.NewGuid():N}.db");
+    private readonly DapperWorkflowInstanceStore _store;
+    private readonly TestTenantAccessor _tenantAccessor = new();
+
+    public DapperWorkflowInstanceStoreTests()
+    {
+        var connectionString = new SqliteConnectionStringBuilder { DataSource = _databasePath, Pooling = false }.ToString();
+        var connectionProvider = new SqliteDbConnectionProvider(connectionString);
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        connection.Execute("""
+                           create table WorkflowInstances (
+                               Id text not null primary key,
+                               TenantId text null,
+                               DefinitionId text not null,
+                               DefinitionVersionId text not null,
+                               Version integer not null,
+                               WorkflowState text not null,
+                               Status text not null,
+                               SubStatus text not null,
+                               IsExecuting integer not null,
+                               CorrelationId text null,
+                               Name text null,
+                               IncidentCount integer not null,
+                               IsSystem integer not null,
+                               CreatedAt text not null,
+                               UpdatedAt text null,
+                               FinishedAt text null
+                           );
+                           """);
+
+        // Seeded through parameters rather than literals so the driver writes the timestamps in
+        // exactly the format it later binds them in for comparison.
+        Insert(connection, "stale-executing", Cutoff.AddMinutes(-5), isExecuting: true);
+        Insert(connection, "stale-idle", Cutoff.AddMinutes(-1), isExecuting: false);
+        Insert(connection, "at-cutoff", Cutoff, isExecuting: true);
+        Insert(connection, "fresh-executing", Cutoff.AddMinutes(4), isExecuting: true);
+
+        var store = new Store<WorkflowInstanceRecord>(connectionProvider, _tenantAccessor, "WorkflowInstances");
+        _store = new DapperWorkflowInstanceStore(store, Substitute.For<IWorkflowStateSerializer>());
+    }
+
+    [Fact]
+    public async Task FindManyIdsAsync_WithBeforeLastUpdated_ExcludesInstancesUpdatedAtOrAfterTheCutoff()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var ids = await _store.FindManyIdsAsync(new WorkflowInstanceFilter { BeforeLastUpdated = Cutoff });
+
+        Assert.Equal(["stale-executing", "stale-idle"], ids.Order());
+    }
+
+    /// <summary>
+    /// Mirrors the filter used by RestartInterruptedWorkflowsTask. An instance that is executing right
+    /// now must not be reported as interrupted, or it gets restarted from the beginning mid-flight.
+    /// </summary>
+    [Fact]
+    public async Task FindManyIdsAsync_WithBeforeLastUpdatedAndIsExecuting_ExcludesInstancesThatAreStillActive()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var ids = await _store.FindManyIdsAsync(new WorkflowInstanceFilter
+        {
+            IsExecuting = true,
+            BeforeLastUpdated = Cutoff
+        });
+
+        Assert.Equal(["stale-executing"], ids);
+    }
+
+    [Fact]
+    public async Task FindManyIdsAsync_WithoutBeforeLastUpdated_ReturnsAllInstances()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var ids = await _store.FindManyIdsAsync(new WorkflowInstanceFilter());
+
+        Assert.Equal(["at-cutoff", "fresh-executing", "stale-executing", "stale-idle"], ids.Order());
+    }
+
+    [Fact]
+    public async Task CountAsync_WithBeforeLastUpdated_CountsOnlyInstancesUpdatedBeforeTheCutoff()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+
+        var count = await _store.CountAsync(new WorkflowInstanceFilter { BeforeLastUpdated = Cutoff });
+
+        Assert.Equal(2, count);
+    }
+
+    public void Dispose()
+    {
+        File.Delete(_databasePath);
+    }
+
+    private static void Insert(SqliteConnection connection, string id, DateTimeOffset updatedAt, bool isExecuting)
+    {
+        connection.Execute(
+            """
+            insert into WorkflowInstances
+                (Id, TenantId, DefinitionId, DefinitionVersionId, Version, WorkflowState, Status, SubStatus, IsExecuting, IncidentCount, IsSystem, CreatedAt, UpdatedAt)
+            values
+                (@Id, 'tenant-a', 'definition-1', 'definition-1:1', 1, '{}', 'Running', 'Executing', @IsExecuting, 0, 0, @CreatedAt, @UpdatedAt);
+            """,
+            new
+            {
+                Id = id,
+                IsExecuting = isExecuting,
+                CreatedAt = updatedAt,
+                UpdatedAt = updatedAt
+            });
+    }
+
+    private sealed class TestTenantAccessor : ITenantAccessor
+    {
+        public string TenantId => Tenant?.Id ?? Elsa.Common.Multitenancy.Tenant.DefaultTenantId;
+        public Tenant? Tenant { get; private set; }
+
+        public IDisposable PushContext(Tenant? tenant)
+        {
+            var previousTenant = Tenant;
+            Tenant = tenant;
+            return new Restore(() => Tenant = previousTenant);
+        }
+
+        private sealed class Restore(Action restore) : IDisposable
+        {
+            public void Dispose() => restore();
+        }
+    }
+}

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/Elsa.Dapper.UnitTests.csproj
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/Elsa.Dapper.UnitTests.csproj
@@ -5,6 +5,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Data.Sqlite" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\modules\persistence\Elsa.Persistence.Dapper\Elsa.Persistence.Dapper.csproj" />
     </ItemGroup>
 

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/ParameterizedQueryBuilderExtensionsTests.cs
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/ParameterizedQueryBuilderExtensionsTests.cs
@@ -1,0 +1,39 @@
+using Elsa.Persistence.Dapper.Dialects;
+using Elsa.Persistence.Dapper.Extensions;
+using Elsa.Persistence.Dapper.Models;
+
+namespace Elsa.Dapper.UnitTests;
+
+public class ParameterizedQueryBuilderExtensionsTests
+{
+    [Fact(DisplayName = "LessThan appends an exclusive comparison and binds @{field}")]
+    public void LessThan_WithValue_AppendsExclusiveComparison()
+    {
+        var cutoff = new DateTimeOffset(2026, 1, 1, 12, 5, 0, TimeSpan.Zero);
+        var query = new ParameterizedQuery(new SqliteDialect())
+            .From("WorkflowInstances")
+            .LessThan("UpdatedAt", cutoff);
+
+        var sql = query.Sql.ToString();
+
+        Assert.Contains("and UpdatedAt < @UpdatedAt", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("<=", sql, StringComparison.Ordinal);
+        Assert.Equal(cutoff, query.Parameters.Get<DateTimeOffset>("UpdatedAt"));
+    }
+
+    [Fact(DisplayName = "LessThan is a no-op when the value is null")]
+    public void LessThan_WithNullValue_PreservesOtherFilters()
+    {
+        var query = new ParameterizedQuery(new SqliteDialect())
+            .From("WorkflowInstances")
+            .Is("IsExecuting", true)
+            .LessThan("UpdatedAt", null);
+
+        var sql = query.Sql.ToString();
+
+        Assert.Contains("and IsExecuting = @IsExecuting", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("UpdatedAt", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("UpdatedAt", query.Parameters.ParameterNames);
+        Assert.True(query.Parameters.Get<bool>("IsExecuting"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`DapperWorkflowInstanceStore.ApplyFilter` accepted `WorkflowInstanceFilter.BeforeLastUpdated` and then dropped it from the generated SQL. `RestartInterruptedWorkflowsTask` relies on that property to distinguish a genuinely interrupted workflow from one that is merely executing right now. On Dapper the inactivity guard was a no-op, so every mid-execution instance was restarted from the beginning.

The canonical EF/`IQueryable` filter honours `UpdatedAt < BeforeLastUpdated`. This is specific to the Dapper provider.

## Change

`git cherry-pick -x 28fcb585` from community PR #184 onto clean `release/3.8.1` (includes merged #188 `TryMarkInterruptedAsync`). Tests were relocated to `Elsa.Dapper.UnitTests` to match the 3.8.1 layout (the original commit targeted `Elsa.Persistence.Dapper.UnitTests` on `main`).

- Add `ParameterizedQueryBuilderExtensions.LessThan` — null short-circuit, `@{field}` params, direct SQL (same shape as `StartsWith`; `<` is identical across SQLite, SQL Server, and PostgreSQL).
- Apply `filter.BeforeLastUpdated` in `ApplyFilter` via `LessThan(UpdatedAt, ...)`.
- Store + `LessThan` unit tests in `Elsa.Dapper.UnitTests`.

Does **not** bring `main` history. Does **not** undo `TryMarkInterruptedAsync` / `WHERE 1=1` from #188.

## Credit

Community fix by **Ronald Kroon** (`ronald.kroon@avivasolutions.nl`), author of `28fcb585`. This commit is a `cherry-pick -x` of that SHA (author preserved) and includes `Co-authored-by: Ronald Kroon <ronald.kroon@avivasolutions.nl>`.

## Tests

```
dotnet test test/modules/persistence/Elsa.Dapper.UnitTests
```

7 passed (0 failed), including the existing `TryMarkInterruptedAsync` / `WHERE 1=1` query test (no regression of #188).

SHA: `0e32faae8ddc1b4886128bde811a8e73e8fcdb0a`

## Out of scope

`TimestampFilters` is still ignored by this store. It needs date-range semantics and column-name normalisation; leave that for a follow-up.

## Relation to #184

This replaces community PR #184 **for the 3.8.1 train**. #184 was retargeted from `main` to `release/3.8.1` and now carries thousands of unrelated files (and would regress #188). Leave #184 alone; retarget it back to `main` if that is still the intended landing branch there.

Fixes #183

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ee16b10-8bec-5d51-a53b-790ed21068e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ee16b10-8bec-5d51-a53b-790ed21068e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

