### PR TITLE
fix: allow TryMarkInterrupted to promote Finished/Cancelled

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
@@ -176,16 +176,25 @@ internal class DapperWorkflowInstanceStore(Store<WorkflowInstanceRecord> store, 
         var record = new WorkflowInstanceRecord
         {
             Id = workflowInstanceId,
+            Status = WorkflowStatus.Running.ToString(),
             SubStatus = WorkflowSubStatus.Interrupted.ToString(),
             IsExecuting = false
         };
 
         var updated = await store.UpdateAsync(
             record,
-            [x => x.SubStatus, x => x.IsExecuting],
-            q => q
-                .Is(nameof(WorkflowInstanceRecord.Id), workflowInstanceId)
-                .IsNot(nameof(WorkflowInstanceRecord.Status), WorkflowStatus.Finished.ToString()),
+            [x => x.Status, x => x.SubStatus, x => x.IsExecuting],
+            q =>
+            {
+                q.Is(nameof(WorkflowInstanceRecord.Id), workflowInstanceId);
+                // Naturally completed rows (Finished && SubStatus != Cancelled) must not be
+                // interrupted. Finished/Cancelled is the runner's drain force-cancel commit
+                // and is interruptible (elsa-core#8069). Distinct param names avoid colliding
+                // with the SET Status = Running assignment.
+                q.Sql.AppendLine("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)");
+                q.Parameters.Add("@FinishedStatus", WorkflowStatus.Finished.ToString());
+                q.Parameters.Add("@CancelledSubStatus", WorkflowSubStatus.Cancelled.ToString());
+            },
             cancellationToken);
 
         return updated > 0;

--- a/src/modules/persistence/Elsa.Persistence.Elasticsearch/Common/ElasticStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Elasticsearch/Common/ElasticStore.cs
@@ -124,4 +124,17 @@ public class ElasticStore<T> where T : class
 
         return response.Deleted ?? 0;
     }
+
+    /// <summary>
+    /// Updates documents matching the specified query. Returns the number of documents updated.
+    /// </summary>
+    public async Task<long> UpdateByQueryAsync(Action<UpdateByQueryRequestDescriptor<T>> query, CancellationToken cancellationToken)
+    {
+        var response = await _elasticClient.UpdateByQueryAsync(Indices.All, query, cancellationToken);
+
+        if (!response.IsSuccess())
+            throw new Exception(response.DebugInformation);
+
+        return response.Updated ?? 0;
+    }
 }

--- a/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
@@ -153,29 +153,33 @@ public class ElasticWorkflowInstanceStore : IWorkflowInstanceStore
     /// <inheritdoc />
     public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default)
     {
-        var instance = await FindAsync(new WorkflowInstanceFilter
-        {
-            Id = workflowInstanceId
-        }, cancellationToken);
+        // Conditional write: do not SaveAsync a Find snapshot. Id is a document field
+        // (not mapped as _id), so Update-by-id is unavailable. UpdateByQuery applies
+        // the same interruptible predicate as EF/Mongo (elsa-core#8069):
+        // Status != Finished OR SubStatus == Cancelled.
+        var updated = await _store.UpdateByQueryAsync(d => d
+            .Refresh(true)
+            .Query(q => q.Bool(b => b
+                .Must(
+                    m => m.Match(mt => mt.Field(f => f.Id).Query(workflowInstanceId)),
+                    m => m.Bool(s => s
+                        .Should(
+                            sh => sh.Bool(n => n.MustNot(mn => mn.Match(mt => mt
+                                .Field(f => f.Status)
+                                .Query(WorkflowStatus.Finished.ToString()!)))),
+                            sh => sh.Match(mt => mt
+                                .Field(f => f.SubStatus)
+                                .Query(WorkflowSubStatus.Cancelled.ToString()!)))
+                        .MinimumShouldMatch(1)))))
+            .Script(s => s
+                .Source("ctx._source.status = params.status; ctx._source.subStatus = params.subStatus; ctx._source.isExecuting = params.isExecuting;")
+                .AddParam("status", WorkflowStatus.Running.ToString())
+                .AddParam("subStatus", WorkflowSubStatus.Interrupted.ToString())
+                .AddParam("isExecuting", false)),
+            cancellationToken);
 
-        if (instance is null || IsNaturallyCompleted(instance))
-            return false;
-
-        // Finished/Cancelled is the runner's commit after drain force-cancel. Promote to
-        // Running+Interrupted so the recovery scan (Running+Interrupted) can requeue it.
-        instance.Status = WorkflowStatus.Running;
-        instance.SubStatus = WorkflowSubStatus.Interrupted;
-        instance.IsExecuting = false;
-        await _store.SaveAsync(instance, cancellationToken);
-        return true;
+        return updated > 0;
     }
-
-    /// <summary>
-    /// Naturally completed rows must not be interrupted. Finished/Cancelled is the opposite:
-    /// that is the expected runner commit after a drain force-cancel and is interruptible.
-    /// </summary>
-    private static bool IsNaturallyCompleted(WorkflowInstance instance) =>
-        instance.Status == WorkflowStatus.Finished && instance.SubStatus != WorkflowSubStatus.Cancelled;
 
     private static SearchRequestDescriptor<WorkflowInstance> Sort<TProp>(SearchRequestDescriptor<WorkflowInstance> descriptor, WorkflowInstanceOrder<TProp> order)
     {

--- a/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
@@ -158,14 +158,24 @@ public class ElasticWorkflowInstanceStore : IWorkflowInstanceStore
             Id = workflowInstanceId
         }, cancellationToken);
 
-        if (instance is null || instance.Status == WorkflowStatus.Finished)
+        if (instance is null || IsNaturallyCompleted(instance))
             return false;
 
+        // Finished/Cancelled is the runner's commit after drain force-cancel. Promote to
+        // Running+Interrupted so the recovery scan (Running+Interrupted) can requeue it.
+        instance.Status = WorkflowStatus.Running;
         instance.SubStatus = WorkflowSubStatus.Interrupted;
         instance.IsExecuting = false;
         await _store.SaveAsync(instance, cancellationToken);
         return true;
     }
+
+    /// <summary>
+    /// Naturally completed rows must not be interrupted. Finished/Cancelled is the opposite:
+    /// that is the expected runner commit after a drain force-cancel and is interruptible.
+    /// </summary>
+    private static bool IsNaturallyCompleted(WorkflowInstance instance) =>
+        instance.Status == WorkflowStatus.Finished && instance.SubStatus != WorkflowSubStatus.Cancelled;
 
     private static SearchRequestDescriptor<WorkflowInstance> Sort<TProp>(SearchRequestDescriptor<WorkflowInstance> descriptor, WorkflowInstanceOrder<TProp> order)
     {

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Management/WorkflowInstanceStore.cs
@@ -142,10 +142,15 @@ public class MongoWorkflowInstanceStore(MongoDbStore<WorkflowInstance> mongoDbSt
     public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default)
     {
         var collection = mongoDbStore.GetCollection();
+        // Interruptible = not naturally completed. Finished/Cancelled is the runner's commit
+        // after drain force-cancel and must become Running+Interrupted (elsa-core#8069).
         var filter = Builders<WorkflowInstance>.Filter.And(
             Builders<WorkflowInstance>.Filter.Eq(x => x.Id, workflowInstanceId),
-            Builders<WorkflowInstance>.Filter.Ne(x => x.Status, WorkflowStatus.Finished));
+            Builders<WorkflowInstance>.Filter.Or(
+                Builders<WorkflowInstance>.Filter.Ne(x => x.Status, WorkflowStatus.Finished),
+                Builders<WorkflowInstance>.Filter.Eq(x => x.SubStatus, WorkflowSubStatus.Cancelled)));
         var update = Builders<WorkflowInstance>.Update
+            .Set(x => x.Status, WorkflowStatus.Running)
             .Set(x => x.SubStatus, WorkflowSubStatus.Interrupted)
             .Set(x => x.IsExecuting, false);
 

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
@@ -15,15 +15,16 @@ public sealed class DapperWorkflowInstanceStoreTests : IDisposable
     private static readonly DateTimeOffset Cutoff = new(2026, 1, 1, 12, 5, 0, TimeSpan.Zero);
 
     private readonly string _databasePath = Path.Combine(Path.GetTempPath(), $"elsa-dapper-instances-{Guid.NewGuid():N}.db");
+    private readonly string _connectionString;
     private readonly DapperWorkflowInstanceStore _store;
     private readonly TestTenantAccessor _tenantAccessor = new();
 
     public DapperWorkflowInstanceStoreTests()
     {
-        var connectionString = new SqliteConnectionStringBuilder { DataSource = _databasePath, Pooling = false }.ToString();
-        var connectionProvider = new SqliteDbConnectionProvider(connectionString);
+        _connectionString = new SqliteConnectionStringBuilder { DataSource = _databasePath, Pooling = false }.ToString();
+        var connectionProvider = new SqliteDbConnectionProvider(_connectionString);
 
-        using var connection = new SqliteConnection(connectionString);
+        using var connection = new SqliteConnection(_connectionString);
         connection.Open();
         connection.Execute("""
                            create table WorkflowInstances (
@@ -105,23 +106,97 @@ public sealed class DapperWorkflowInstanceStoreTests : IDisposable
         Assert.Equal(2, count);
     }
 
+    [Fact(DisplayName = "TryMarkInterruptedAsync marks a Running instance as Running+Interrupted")]
+    public async Task TryMarkInterruptedAsync_MarksRunningInstance()
+    {
+        InsertInterruptible("running-1", WorkflowStatus.Running, WorkflowSubStatus.Executing, isExecuting: true);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("running-1");
+
+        Assert.True(marked);
+        Assert.Equal(("Running", "Interrupted", 0), ReadMarkers("running-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync promotes Finished/Cancelled to Running+Interrupted")]
+    public async Task TryMarkInterruptedAsync_MarksCancelledInstance()
+    {
+        InsertInterruptible("cancelled-1", WorkflowStatus.Finished, WorkflowSubStatus.Cancelled, isExecuting: false);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("cancelled-1");
+
+        Assert.True(marked);
+        Assert.Equal(("Running", "Interrupted", 0), ReadMarkers("cancelled-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync refuses naturally completed Finished/Finished")]
+    public async Task TryMarkInterruptedAsync_RefusesFinishedInstance()
+    {
+        InsertInterruptible("finished-1", WorkflowStatus.Finished, WorkflowSubStatus.Finished, isExecuting: false);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("finished-1");
+
+        Assert.False(marked);
+        Assert.Equal(("Finished", "Finished", 0), ReadMarkers("finished-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync refuses naturally completed Finished/Faulted")]
+    public async Task TryMarkInterruptedAsync_RefusesFaultedInstance()
+    {
+        InsertInterruptible("faulted-1", WorkflowStatus.Finished, WorkflowSubStatus.Faulted, isExecuting: false);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("faulted-1");
+
+        Assert.False(marked);
+        Assert.Equal(("Finished", "Faulted", 0), ReadMarkers("faulted-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync returns false when the instance is missing")]
+    public async Task TryMarkInterruptedAsync_ReturnsFalseWhenMissing()
+    {
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("missing-1");
+
+        Assert.False(marked);
+    }
+
     public void Dispose()
     {
         File.Delete(_databasePath);
     }
 
-    private static void Insert(SqliteConnection connection, string id, DateTimeOffset updatedAt, bool isExecuting)
+    private void InsertInterruptible(string id, WorkflowStatus status, WorkflowSubStatus subStatus, bool isExecuting)
+    {
+        using var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+        Insert(connection, id, Cutoff.AddMinutes(-2), isExecuting, status.ToString(), subStatus.ToString());
+    }
+
+    private (string Status, string SubStatus, long IsExecuting) ReadMarkers(string id)
+    {
+        using var connection = new SqliteConnection(_connectionString);
+        return connection.QuerySingle<(string, string, long)>(
+            "select Status, SubStatus, IsExecuting from WorkflowInstances where Id = @Id",
+            new { Id = id });
+    }
+
+    private static void Insert(SqliteConnection connection, string id, DateTimeOffset updatedAt, bool isExecuting, string status = "Running", string subStatus = "Executing")
     {
         connection.Execute(
             """
             insert into WorkflowInstances
                 (Id, TenantId, DefinitionId, DefinitionVersionId, Version, WorkflowState, Status, SubStatus, IsExecuting, IncidentCount, IsSystem, CreatedAt, UpdatedAt)
             values
-                (@Id, 'tenant-a', 'definition-1', 'definition-1:1', 1, '{}', 'Running', 'Executing', @IsExecuting, 0, 0, @CreatedAt, @UpdatedAt);
+                (@Id, 'tenant-a', 'definition-1', 'definition-1:1', 1, '{}', @Status, @SubStatus, @IsExecuting, 0, 0, @CreatedAt, @UpdatedAt);
             """,
             new
             {
                 Id = id,
+                Status = status,
+                SubStatus = subStatus,
                 IsExecuting = isExecuting,
                 CreatedAt = updatedAt,
                 UpdatedAt = updatedAt

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/TryMarkInterruptedQueryTests.cs
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/TryMarkInterruptedQueryTests.cs
@@ -7,29 +7,34 @@ namespace Elsa.Dapper.UnitTests;
 
 public class TryMarkInterruptedQueryTests
 {
-    [Fact(DisplayName = "Conditional interrupt update targets non-terminal rows only")]
-    public void UpdateQuery_IncludesIdAndNonFinishedStatus()
+    [Fact(DisplayName = "Conditional interrupt update allows Running or Finished/Cancelled")]
+    public void UpdateQuery_AllowsRunningOrFinishedCancelled()
     {
         var record = new
         {
             Id = "running-1",
+            Status = WorkflowStatus.Running.ToString(),
             SubStatus = WorkflowSubStatus.Interrupted.ToString(),
             IsExecuting = false
         };
 
         var query = new ParameterizedQuery(new SqliteDialect())
-            .Update("WorkflowInstances", record, ["SubStatus", "IsExecuting"])
-            .Is("Id", record.Id)
-            .IsNot("Status", WorkflowStatus.Finished.ToString());
+            .Update("WorkflowInstances", record, ["Status", "SubStatus", "IsExecuting"])
+            .Is("Id", record.Id);
+        query.Sql.AppendLine("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)");
+        query.Parameters.Add("@FinishedStatus", WorkflowStatus.Finished.ToString());
+        query.Parameters.Add("@CancelledSubStatus", WorkflowSubStatus.Cancelled.ToString());
 
         var sql = query.Sql.ToString();
 
-        Assert.Contains("UPDATE WorkflowInstances SET SubStatus = @SubStatus, IsExecuting = @IsExecuting WHERE 1=1", sql, StringComparison.Ordinal);
+        Assert.Contains("UPDATE WorkflowInstances SET Status = @Status, SubStatus = @SubStatus, IsExecuting = @IsExecuting WHERE 1=1", sql, StringComparison.Ordinal);
         Assert.Contains("and Id = @Id", sql, StringComparison.Ordinal);
-        Assert.Contains("and not Status = @Status", sql, StringComparison.Ordinal);
+        Assert.Contains("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)", sql, StringComparison.Ordinal);
+        Assert.Equal(WorkflowStatus.Running.ToString(), query.Parameters.Get<string>("Status"));
         Assert.Equal(WorkflowSubStatus.Interrupted.ToString(), query.Parameters.Get<string>("SubStatus"));
         Assert.False(query.Parameters.Get<bool>("IsExecuting"));
         Assert.Equal("running-1", query.Parameters.Get<string>("Id"));
-        Assert.Equal(WorkflowStatus.Finished.ToString(), query.Parameters.Get<string>("Status"));
+        Assert.Equal(WorkflowStatus.Finished.ToString(), query.Parameters.Get<string>("FinishedStatus"));
+        Assert.Equal(WorkflowSubStatus.Cancelled.ToString(), query.Parameters.Get<string>("CancelledSubStatus"));
     }
 }

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowInstanceStoreTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowInstanceStoreTests.cs
@@ -13,7 +13,7 @@ namespace Elsa.MongoDb.UnitTests;
 
 public class MongoWorkflowInstanceStoreTests
 {
-    [Fact(DisplayName = "TryMarkInterruptedAsync updates only when Status is not Finished")]
+    [Fact(DisplayName = "TryMarkInterruptedAsync updates Running instances to Running+Interrupted")]
     public async Task TryMarkInterruptedAsync_UpdatesNonTerminalInstance()
     {
         var (store, collection) = CreateStore(matchedCount: 1);
@@ -22,14 +22,29 @@ public class MongoWorkflowInstanceStoreTests
 
         Assert.True(marked);
         await collection.Received(1).UpdateOneAsync(
-            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterMentionsIdAndNonFinished(filter, "running-1")),
-            Arg.Is<UpdateDefinition<WorkflowInstance>>(update => UpdateSetsInterruptedMarkers(update)),
+            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterAllowsInterruptible(filter, "running-1")),
+            Arg.Is<UpdateDefinition<WorkflowInstance>>(update => UpdatePromotesToRunningInterrupted(update)),
             Arg.Any<UpdateOptions>(),
             Arg.Any<CancellationToken>());
     }
 
-    [Fact(DisplayName = "TryMarkInterruptedAsync returns false when no non-terminal instance matches")]
-    public async Task TryMarkInterruptedAsync_ReturnsFalseWhenMissingOrFinished()
+    [Fact(DisplayName = "TryMarkInterruptedAsync filter allows Finished/Cancelled (drain force-cancel)")]
+    public async Task TryMarkInterruptedAsync_FilterAllowsFinishedCancelled()
+    {
+        var (store, collection) = CreateStore(matchedCount: 1);
+
+        var marked = await store.TryMarkInterruptedAsync("cancelled-1");
+
+        Assert.True(marked);
+        await collection.Received(1).UpdateOneAsync(
+            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterAllowsInterruptible(filter, "cancelled-1")),
+            Arg.Is<UpdateDefinition<WorkflowInstance>>(update => UpdatePromotesToRunningInterrupted(update)),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync returns false when no interruptible instance matches")]
+    public async Task TryMarkInterruptedAsync_ReturnsFalseWhenMissingOrNaturallyCompleted()
     {
         var (store, _) = CreateStore(matchedCount: 0);
 
@@ -58,19 +73,28 @@ public class MongoWorkflowInstanceStoreTests
         return (store, collection);
     }
 
-    private static bool FilterMentionsIdAndNonFinished(FilterDefinition<WorkflowInstance> filter, string id)
+    /// <summary>
+    /// Id match plus the IsNaturallyCompleted inverse: Status != Finished OR SubStatus == Cancelled.
+    /// Refuses Finished/Finished and Finished/Faulted at the filter.
+    /// </summary>
+    private static bool FilterAllowsInterruptible(FilterDefinition<WorkflowInstance> filter, string id)
     {
         var rendered = Render(filter);
         return rendered.Contains(id, StringComparison.Ordinal)
+               && rendered.Contains("$or", StringComparison.Ordinal)
                && rendered.Contains("Status", StringComparison.Ordinal)
                && rendered.Contains("$ne", StringComparison.Ordinal)
-               && rendered.Contains(((int)WorkflowStatus.Finished).ToString(), StringComparison.Ordinal);
+               && rendered.Contains(((int)WorkflowStatus.Finished).ToString(), StringComparison.Ordinal)
+               && rendered.Contains("SubStatus", StringComparison.Ordinal)
+               && rendered.Contains(((int)WorkflowSubStatus.Cancelled).ToString(), StringComparison.Ordinal);
     }
 
-    private static bool UpdateSetsInterruptedMarkers(UpdateDefinition<WorkflowInstance> update)
+    private static bool UpdatePromotesToRunningInterrupted(UpdateDefinition<WorkflowInstance> update)
     {
         var rendered = Render(update);
         return rendered.Contains("$set", StringComparison.Ordinal)
+               && rendered.Contains("Status", StringComparison.Ordinal)
+               && rendered.Contains(((int)WorkflowStatus.Running).ToString(), StringComparison.Ordinal)
                && rendered.Contains("SubStatus", StringComparison.Ordinal)
                && rendered.Contains(((int)WorkflowSubStatus.Interrupted).ToString(), StringComparison.Ordinal)
                && rendered.Contains("IsExecuting", StringComparison.Ordinal);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Post-cut provider parity for 3.8.1 so Mongo/Dapper/Elasticsearch hosts keep DeadlineBreach working after [elsa-core#8069](https://github.com/elsa-workflows/elsa-core/pull/8069) merges. Do not merge, retag, or publish from this PR.

Crew Lead: dual gates on extensions = Code Review APPROVE+HIGH only (Greptile waived).

---

## Scope

Select one primary concern:
- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

Mirrors core#8069 exactly:

- Allow `Finished/Cancelled` → set `Status=Running`, `SubStatus=Interrupted`, `IsExecuting=false`
- Refuse `Finished/Finished` and `Finished/Faulted` (and any other non-Cancelled Finished)
- Keep each store’s atomic/conditional write shape — **no `SaveAsync` of a Find snapshot**
- Do not invent a second Cancelled meaning (Cancelled is only the runner’s drain force-cancel commit)

| Store | Conditional write |
|---|---|
| Mongo | `UpdateOne` with `Id` and `Status != Finished OR SubStatus == Cancelled` |
| Dapper | `UPDATE … SET Status, SubStatus, IsExecuting WHERE Id AND (not Status = Finished OR SubStatus = Cancelled)` |
| Elasticsearch | `UpdateByQuery` with the same predicate + painless script (not Find+Save) |

### Architect notes (predicate expression)

- **Mongo:** `Filter.Or(Ne(Status, Finished), Eq(SubStatus, Cancelled))` — clean equivalent of EF’s `(Status != Finished \|\| SubStatus == Cancelled)`.
- **Dapper:** the query builder has no `Or()`. The store appends a raw `WHERE` fragment with distinct `@FinishedStatus` / `@CancelledSubStatus` params so they do not collide with `SET Status = Running`. Same predicate, not a second Cancelled meaning. No builder redesign in this patch.
- **Elasticsearch:** `WorkflowInstance.Id` is a document field (`DefaultMappingFor` does not map it to `_id`), so Update-by-id would require a Find first. `UpdateByQuery` is the conditional write that can express the OR Cancelled predicate without `SaveAsync` of a snapshot. Query uses the same `Match` field style as this store’s existing filters; script sets camelCase `status` / `subStatus` / `isExecuting` as strings (`ToString()`), consistent with those filters.

---

## Verification

Local `net10.0` (SDK 10.0.401) @ `db4c499da9e349afc9bc3b9693b0368009b17803` (tests re-run after the ES UpdateByQuery revision):

```
dotnet test test/modules/persistence/Elsa.MongoDb.UnitTests --filter TryMarkInterrupted
dotnet test test/modules/persistence/Elsa.Dapper.UnitTests --filter TryMarkInterrupted
dotnet build src/modules/persistence/Elsa.Persistence.Elasticsearch
```

`pr.yml` only triggers on PRs into `main`, so this `release/3.8.1` PR will not get that workflow.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] Targeted tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccefac95-8a7d-5868-9de9-36f159ed18c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccefac95-8a7d-5868-9de9-36f159ed18c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

