### PR TITLE
fix: gate Cancelled interrupt promote behind allowFinishedCancelled

### DIFF
--- a/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Dapper/Modules/Management/Stores/DapperWorkflowInstanceStore.cs
@@ -171,7 +171,7 @@ internal class DapperWorkflowInstanceStore(Store<WorkflowInstanceRecord> store, 
     }
 
     /// <inheritdoc />
-    public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default)
+    public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default, bool allowFinishedCancelled = false)
     {
         var record = new WorkflowInstanceRecord
         {
@@ -187,13 +187,19 @@ internal class DapperWorkflowInstanceStore(Store<WorkflowInstanceRecord> store, 
             q =>
             {
                 q.Is(nameof(WorkflowInstanceRecord.Id), workflowInstanceId);
-                // Naturally completed rows (Finished && SubStatus != Cancelled) must not be
-                // interrupted. Finished/Cancelled is the runner's drain force-cancel commit
-                // and is interruptible (elsa-core#8069). Distinct param names avoid colliding
-                // with the SET Status = Running assignment.
-                q.Sql.AppendLine("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)");
+                // Default: refuse every Finished row (#8052). Distinct param names avoid
+                // colliding with SET Status = Running. Drain PersistInterrupted alone may
+                // pass allowFinishedCancelled (elsa-core#8069).
                 q.Parameters.Add("@FinishedStatus", WorkflowStatus.Finished.ToString());
-                q.Parameters.Add("@CancelledSubStatus", WorkflowSubStatus.Cancelled.ToString());
+                if (allowFinishedCancelled)
+                {
+                    q.Sql.AppendLine("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)");
+                    q.Parameters.Add("@CancelledSubStatus", WorkflowSubStatus.Cancelled.ToString());
+                }
+                else
+                {
+                    q.Sql.AppendLine("and not Status = @FinishedStatus");
+                }
             },
             cancellationToken);
 

--- a/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
@@ -151,32 +151,45 @@ public class ElasticWorkflowInstanceStore : IWorkflowInstanceStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default)
+    public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default, bool allowFinishedCancelled = false)
     {
         // Conditional write: do not SaveAsync a Find snapshot. Id is a document field
-        // (not mapped as _id), so Update-by-id is unavailable. UpdateByQuery applies
-        // the same interruptible predicate as EF/Mongo (elsa-core#8069):
-        // Status != Finished OR SubStatus == Cancelled.
-        var updated = await _store.UpdateByQueryAsync(d => d
-            .Refresh(true)
-            .Query(q => q.Bool(b => b
-                .Must(
-                    m => m.Match(mt => mt.Field(f => f.Id).Query(workflowInstanceId)),
-                    m => m.Bool(s => s
-                        .Should(
-                            sh => sh.Bool(n => n.MustNot(mn => mn.Match(mt => mt
-                                .Field(f => f.Status)
-                                .Query(WorkflowStatus.Finished.ToString()!)))),
-                            sh => sh.Match(mt => mt
-                                .Field(f => f.SubStatus)
-                                .Query(WorkflowSubStatus.Cancelled.ToString()!)))
-                        .MinimumShouldMatch(1)))))
-            .Script(s => s
+        // (not mapped as _id), so Update-by-id is unavailable. Default UpdateByQuery
+        // refuses every Finished row (#8052). Drain PersistInterrupted alone may pass
+        // allowFinishedCancelled to add Status != Finished OR SubStatus == Cancelled.
+        var updated = await _store.UpdateByQueryAsync(d =>
+        {
+            d.Refresh(true);
+            if (allowFinishedCancelled)
+            {
+                d.Query(q => q.Bool(b => b
+                    .Must(
+                        m => m.Match(mt => mt.Field(f => f.Id).Query(workflowInstanceId)),
+                        m => m.Bool(s => s
+                            .Should(
+                                sh => sh.Bool(n => n.MustNot(mn => mn.Match(mt => mt
+                                    .Field(f => f.Status)
+                                    .Query(WorkflowStatus.Finished.ToString()!)))),
+                                sh => sh.Match(mt => mt
+                                    .Field(f => f.SubStatus)
+                                    .Query(WorkflowSubStatus.Cancelled.ToString()!)))
+                            .MinimumShouldMatch(1)))));
+            }
+            else
+            {
+                d.Query(q => q.Bool(b => b
+                    .Must(m => m.Match(mt => mt.Field(f => f.Id).Query(workflowInstanceId)))
+                    .MustNot(mn => mn.Match(mt => mt
+                        .Field(f => f.Status)
+                        .Query(WorkflowStatus.Finished.ToString()!)))));
+            }
+
+            d.Script(s => s
                 .Source("ctx._source.status = params.status; ctx._source.subStatus = params.subStatus; ctx._source.isExecuting = params.isExecuting;")
                 .AddParam("status", WorkflowStatus.Running.ToString())
                 .AddParam("subStatus", WorkflowSubStatus.Interrupted.ToString())
-                .AddParam("isExecuting", false)),
-            cancellationToken);
+                .AddParam("isExecuting", false));
+        }, cancellationToken);
 
         return updated > 0;
     }

--- a/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Management/WorkflowInstanceStore.cs
@@ -139,16 +139,20 @@ public class MongoWorkflowInstanceStore(MongoDbStore<WorkflowInstance> mongoDbSt
     }
 
     /// <inheritdoc />
-    public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default)
+    public async ValueTask<bool> TryMarkInterruptedAsync(string workflowInstanceId, CancellationToken cancellationToken = default, bool allowFinishedCancelled = false)
     {
         var collection = mongoDbStore.GetCollection();
-        // Interruptible = not naturally completed. Finished/Cancelled is the runner's commit
-        // after drain force-cancel and must become Running+Interrupted (elsa-core#8069).
-        var filter = Builders<WorkflowInstance>.Filter.And(
-            Builders<WorkflowInstance>.Filter.Eq(x => x.Id, workflowInstanceId),
-            Builders<WorkflowInstance>.Filter.Or(
-                Builders<WorkflowInstance>.Filter.Ne(x => x.Status, WorkflowStatus.Finished),
-                Builders<WorkflowInstance>.Filter.Eq(x => x.SubStatus, WorkflowSubStatus.Cancelled)));
+        // Default: refuse every Finished row (#8052). Drain PersistInterrupted alone may pass
+        // allowFinishedCancelled to promote Finished/Cancelled → Running+Interrupted.
+        var idFilter = Builders<WorkflowInstance>.Filter.Eq(x => x.Id, workflowInstanceId);
+        var notFinished = Builders<WorkflowInstance>.Filter.Ne(x => x.Status, WorkflowStatus.Finished);
+        var filter = allowFinishedCancelled
+            ? Builders<WorkflowInstance>.Filter.And(
+                idFilter,
+                Builders<WorkflowInstance>.Filter.Or(
+                    notFinished,
+                    Builders<WorkflowInstance>.Filter.Eq(x => x.SubStatus, WorkflowSubStatus.Cancelled)))
+            : Builders<WorkflowInstance>.Filter.And(idFilter, notFinished);
         var update = Builders<WorkflowInstance>.Update
             .Set(x => x.Status, WorkflowStatus.Running)
             .Set(x => x.SubStatus, WorkflowSubStatus.Interrupted)

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/DapperWorkflowInstanceStoreTests.cs
@@ -118,19 +118,31 @@ public sealed class DapperWorkflowInstanceStoreTests : IDisposable
         Assert.Equal(("Running", "Interrupted", 0), ReadMarkers("running-1"));
     }
 
-    [Fact(DisplayName = "TryMarkInterruptedAsync promotes Finished/Cancelled to Running+Interrupted")]
-    public async Task TryMarkInterruptedAsync_MarksCancelledInstance()
+    [Fact(DisplayName = "TryMarkInterruptedAsync refuses Finished/Cancelled unless allowFinishedCancelled is set")]
+    public async Task TryMarkInterruptedAsync_DoesNotOverwriteCancelledInstanceByDefault()
     {
         InsertInterruptible("cancelled-1", WorkflowStatus.Finished, WorkflowSubStatus.Cancelled, isExecuting: false);
 
         using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
         var marked = await _store.TryMarkInterruptedAsync("cancelled-1");
 
+        Assert.False(marked);
+        Assert.Equal(("Finished", "Cancelled", 0), ReadMarkers("cancelled-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync promotes Finished/Cancelled only when allowFinishedCancelled is true")]
+    public async Task TryMarkInterruptedAsync_PromotesCancelledWhenAllowed()
+    {
+        InsertInterruptible("cancelled-1", WorkflowStatus.Finished, WorkflowSubStatus.Cancelled, isExecuting: false);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("cancelled-1", allowFinishedCancelled: true);
+
         Assert.True(marked);
         Assert.Equal(("Running", "Interrupted", 0), ReadMarkers("cancelled-1"));
     }
 
-    [Fact(DisplayName = "TryMarkInterruptedAsync refuses naturally completed Finished/Finished")]
+    [Fact(DisplayName = "TryMarkInterruptedAsync refuses Finished/Finished")]
     public async Task TryMarkInterruptedAsync_RefusesFinishedInstance()
     {
         InsertInterruptible("finished-1", WorkflowStatus.Finished, WorkflowSubStatus.Finished, isExecuting: false);
@@ -142,13 +154,37 @@ public sealed class DapperWorkflowInstanceStoreTests : IDisposable
         Assert.Equal(("Finished", "Finished", 0), ReadMarkers("finished-1"));
     }
 
-    [Fact(DisplayName = "TryMarkInterruptedAsync refuses naturally completed Finished/Faulted")]
+    [Fact(DisplayName = "TryMarkInterruptedAsync still refuses Finished/Finished when allowFinishedCancelled is true")]
+    public async Task TryMarkInterruptedAsync_RefusesFinishedEvenWhenCancelledAllowed()
+    {
+        InsertInterruptible("finished-1", WorkflowStatus.Finished, WorkflowSubStatus.Finished, isExecuting: false);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("finished-1", allowFinishedCancelled: true);
+
+        Assert.False(marked);
+        Assert.Equal(("Finished", "Finished", 0), ReadMarkers("finished-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync refuses Finished/Faulted")]
     public async Task TryMarkInterruptedAsync_RefusesFaultedInstance()
     {
         InsertInterruptible("faulted-1", WorkflowStatus.Finished, WorkflowSubStatus.Faulted, isExecuting: false);
 
         using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
         var marked = await _store.TryMarkInterruptedAsync("faulted-1");
+
+        Assert.False(marked);
+        Assert.Equal(("Finished", "Faulted", 0), ReadMarkers("faulted-1"));
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync still refuses Finished/Faulted when allowFinishedCancelled is true")]
+    public async Task TryMarkInterruptedAsync_RefusesFaultedEvenWhenCancelledAllowed()
+    {
+        InsertInterruptible("faulted-1", WorkflowStatus.Finished, WorkflowSubStatus.Faulted, isExecuting: false);
+
+        using var tenantScope = _tenantAccessor.PushContext(new Tenant { Id = "tenant-a" });
+        var marked = await _store.TryMarkInterruptedAsync("faulted-1", allowFinishedCancelled: true);
 
         Assert.False(marked);
         Assert.Equal(("Finished", "Faulted", 0), ReadMarkers("faulted-1"));

--- a/test/modules/persistence/Elsa.Dapper.UnitTests/TryMarkInterruptedQueryTests.cs
+++ b/test/modules/persistence/Elsa.Dapper.UnitTests/TryMarkInterruptedQueryTests.cs
@@ -7,20 +7,27 @@ namespace Elsa.Dapper.UnitTests;
 
 public class TryMarkInterruptedQueryTests
 {
-    [Fact(DisplayName = "Conditional interrupt update allows Running or Finished/Cancelled")]
-    public void UpdateQuery_AllowsRunningOrFinishedCancelled()
+    [Fact(DisplayName = "Default interrupt update refuses every Finished row")]
+    public void UpdateQuery_RefusesFinishedByDefault()
     {
-        var record = new
-        {
-            Id = "running-1",
-            Status = WorkflowStatus.Running.ToString(),
-            SubStatus = WorkflowSubStatus.Interrupted.ToString(),
-            IsExecuting = false
-        };
+        var query = CreateInterruptUpdate();
+        query.Sql.AppendLine("and not Status = @FinishedStatus");
+        query.Parameters.Add("@FinishedStatus", WorkflowStatus.Finished.ToString());
 
-        var query = new ParameterizedQuery(new SqliteDialect())
-            .Update("WorkflowInstances", record, ["Status", "SubStatus", "IsExecuting"])
-            .Is("Id", record.Id);
+        var sql = query.Sql.ToString();
+
+        Assert.Contains("UPDATE WorkflowInstances SET Status = @Status, SubStatus = @SubStatus, IsExecuting = @IsExecuting WHERE 1=1", sql, StringComparison.Ordinal);
+        Assert.Contains("and Id = @Id", sql, StringComparison.Ordinal);
+        Assert.Contains("and not Status = @FinishedStatus", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("CancelledSubStatus", sql, StringComparison.Ordinal);
+        AssertSharedInterruptParameters(query);
+        Assert.Equal(WorkflowStatus.Finished.ToString(), query.Parameters.Get<string>("FinishedStatus"));
+    }
+
+    [Fact(DisplayName = "Conditional interrupt update allows Running or Finished/Cancelled when flag is set")]
+    public void UpdateQuery_AllowsRunningOrFinishedCancelledWhenFlagSet()
+    {
+        var query = CreateInterruptUpdate();
         query.Sql.AppendLine("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)");
         query.Parameters.Add("@FinishedStatus", WorkflowStatus.Finished.ToString());
         query.Parameters.Add("@CancelledSubStatus", WorkflowSubStatus.Cancelled.ToString());
@@ -30,11 +37,31 @@ public class TryMarkInterruptedQueryTests
         Assert.Contains("UPDATE WorkflowInstances SET Status = @Status, SubStatus = @SubStatus, IsExecuting = @IsExecuting WHERE 1=1", sql, StringComparison.Ordinal);
         Assert.Contains("and Id = @Id", sql, StringComparison.Ordinal);
         Assert.Contains("and (not Status = @FinishedStatus or SubStatus = @CancelledSubStatus)", sql, StringComparison.Ordinal);
+        AssertSharedInterruptParameters(query);
+        Assert.Equal(WorkflowStatus.Finished.ToString(), query.Parameters.Get<string>("FinishedStatus"));
+        Assert.Equal(WorkflowSubStatus.Cancelled.ToString(), query.Parameters.Get<string>("CancelledSubStatus"));
+    }
+
+    private static ParameterizedQuery CreateInterruptUpdate()
+    {
+        var record = new
+        {
+            Id = "running-1",
+            Status = WorkflowStatus.Running.ToString(),
+            SubStatus = WorkflowSubStatus.Interrupted.ToString(),
+            IsExecuting = false
+        };
+
+        return new ParameterizedQuery(new SqliteDialect())
+            .Update("WorkflowInstances", record, ["Status", "SubStatus", "IsExecuting"])
+            .Is("Id", record.Id);
+    }
+
+    private static void AssertSharedInterruptParameters(ParameterizedQuery query)
+    {
         Assert.Equal(WorkflowStatus.Running.ToString(), query.Parameters.Get<string>("Status"));
         Assert.Equal(WorkflowSubStatus.Interrupted.ToString(), query.Parameters.Get<string>("SubStatus"));
         Assert.False(query.Parameters.Get<bool>("IsExecuting"));
         Assert.Equal("running-1", query.Parameters.Get<string>("Id"));
-        Assert.Equal(WorkflowStatus.Finished.ToString(), query.Parameters.Get<string>("FinishedStatus"));
-        Assert.Equal(WorkflowSubStatus.Cancelled.ToString(), query.Parameters.Get<string>("CancelledSubStatus"));
     }
 }

--- a/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowInstanceStoreTests.cs
+++ b/test/modules/persistence/Elsa.MongoDb.UnitTests/MongoWorkflowInstanceStoreTests.cs
@@ -22,29 +22,64 @@ public class MongoWorkflowInstanceStoreTests
 
         Assert.True(marked);
         await collection.Received(1).UpdateOneAsync(
-            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterAllowsInterruptible(filter, "running-1")),
+            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterRefusesFinished(filter, "running-1")),
             Arg.Is<UpdateDefinition<WorkflowInstance>>(update => UpdatePromotesToRunningInterrupted(update)),
             Arg.Any<UpdateOptions>(),
             Arg.Any<CancellationToken>());
     }
 
-    [Fact(DisplayName = "TryMarkInterruptedAsync filter allows Finished/Cancelled (drain force-cancel)")]
-    public async Task TryMarkInterruptedAsync_FilterAllowsFinishedCancelled()
+    [Fact(DisplayName = "TryMarkInterruptedAsync refuses Finished/Cancelled unless allowFinishedCancelled is set")]
+    public async Task TryMarkInterruptedAsync_FilterRefusesFinishedCancelledByDefault()
     {
-        var (store, collection) = CreateStore(matchedCount: 1);
+        var (store, collection) = CreateStore(matchedCount: 0);
 
         var marked = await store.TryMarkInterruptedAsync("cancelled-1");
 
-        Assert.True(marked);
+        Assert.False(marked);
         await collection.Received(1).UpdateOneAsync(
-            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterAllowsInterruptible(filter, "cancelled-1")),
+            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterRefusesFinished(filter, "cancelled-1")),
             Arg.Is<UpdateDefinition<WorkflowInstance>>(update => UpdatePromotesToRunningInterrupted(update)),
             Arg.Any<UpdateOptions>(),
             Arg.Any<CancellationToken>());
     }
 
+    [Fact(DisplayName = "TryMarkInterruptedAsync filter allows Finished/Cancelled only when allowFinishedCancelled is true")]
+    public async Task TryMarkInterruptedAsync_FilterAllowsFinishedCancelledWhenFlagSet()
+    {
+        var (store, collection) = CreateStore(matchedCount: 1);
+
+        var marked = await store.TryMarkInterruptedAsync("cancelled-1", allowFinishedCancelled: true);
+
+        Assert.True(marked);
+        await collection.Received(1).UpdateOneAsync(
+            Arg.Is<FilterDefinition<WorkflowInstance>>(filter => FilterAllowsFinishedCancelled(filter, "cancelled-1")),
+            Arg.Is<UpdateDefinition<WorkflowInstance>>(update => UpdatePromotesToRunningInterrupted(update)),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync still refuses Finished/Finished when allowFinishedCancelled is true")]
+    public async Task TryMarkInterruptedAsync_RefusesFinishedEvenWhenCancelledAllowed()
+    {
+        var (store, _) = CreateStore(matchedCount: 0);
+
+        var marked = await store.TryMarkInterruptedAsync("finished-1", allowFinishedCancelled: true);
+
+        Assert.False(marked);
+    }
+
+    [Fact(DisplayName = "TryMarkInterruptedAsync still refuses Finished/Faulted when allowFinishedCancelled is true")]
+    public async Task TryMarkInterruptedAsync_RefusesFaultedEvenWhenCancelledAllowed()
+    {
+        var (store, _) = CreateStore(matchedCount: 0);
+
+        var marked = await store.TryMarkInterruptedAsync("faulted-1", allowFinishedCancelled: true);
+
+        Assert.False(marked);
+    }
+
     [Fact(DisplayName = "TryMarkInterruptedAsync returns false when no interruptible instance matches")]
-    public async Task TryMarkInterruptedAsync_ReturnsFalseWhenMissingOrNaturallyCompleted()
+    public async Task TryMarkInterruptedAsync_ReturnsFalseWhenMissingOrFinished()
     {
         var (store, _) = CreateStore(matchedCount: 0);
 
@@ -74,10 +109,24 @@ public class MongoWorkflowInstanceStoreTests
     }
 
     /// <summary>
-    /// Id match plus the IsNaturallyCompleted inverse: Status != Finished OR SubStatus == Cancelled.
-    /// Refuses Finished/Finished and Finished/Faulted at the filter.
+    /// Default filter: Id match and Status != Finished. No store-wide Cancelled OR.
     /// </summary>
-    private static bool FilterAllowsInterruptible(FilterDefinition<WorkflowInstance> filter, string id)
+    private static bool FilterRefusesFinished(FilterDefinition<WorkflowInstance> filter, string id)
+    {
+        var rendered = Render(filter);
+        return rendered.Contains(id, StringComparison.Ordinal)
+               && rendered.Contains("Status", StringComparison.Ordinal)
+               && rendered.Contains("$ne", StringComparison.Ordinal)
+               && rendered.Contains(((int)WorkflowStatus.Finished).ToString(), StringComparison.Ordinal)
+               && !rendered.Contains("$or", StringComparison.Ordinal)
+               && !rendered.Contains(((int)WorkflowSubStatus.Cancelled).ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Flag-true filter: Id match plus Status != Finished OR SubStatus == Cancelled.
+    /// Still refuses Finished/Finished and Finished/Faulted at the filter.
+    /// </summary>
+    private static bool FilterAllowsFinishedCancelled(FilterDefinition<WorkflowInstance> filter, string id)
     {
         var rendered = Render(filter);
         return rendered.Contains(id, StringComparison.Ordinal)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

3.8.1 parity amend after [elsa-core#8069](https://github.com/elsa-workflows/elsa-core/pull/8069) tip `bc04b84`. Do **not** leave the store-wide Cancelled allow merged in #190. Do not merge, retag, or publish from this PR.

Crew Lead: dual gates on extensions = Code Review APPROVE+HIGH only (Greptile waived).

---

## Scope

Select one primary concern:
- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

Mirrors core#8069 `TryMarkInterruptedAsync(..., bool allowFinishedCancelled = false)`:

- **Default:** refuse every `Finished` row (undo #190 store-wide `Cancelled` OR)
- **Flag true:** promote `Finished/Cancelled` → `Running` + `Interrupted`, `IsExecuting=false`
- Still refuse `Finished/Finished` and `Finished/Faulted`
- Keep each store’s atomic/conditional write shape — **no `SaveAsync` of a Find snapshot**

| Store | Conditional write |
|---|---|
| Mongo | `UpdateOne` with `Id` and `Status != Finished`, plus `OR SubStatus == Cancelled` only when the flag is true |
| Dapper | `UPDATE … SET Status, SubStatus, IsExecuting WHERE Id` and raw `not Status = Finished`, plus `OR SubStatus = Cancelled` only when the flag is true |
| Elasticsearch | `UpdateByQuery` with the same predicate + painless script (not Find+Save) |

Drain `PersistInterrupted` alone passes the flag for the force-cancelled set. User cancellations stay cancelled.

---

## Verification

Local `net10.0` (SDK 10.0.401) @ `bc9c16f7d9ee1832848c264f770c3846e55e2902`:

```
dotnet test test/modules/persistence/Elsa.MongoDb.UnitTests --filter TryMarkInterrupted
  Passed!  - Failed: 0, Passed: 6, Skipped: 0

dotnet test test/modules/persistence/Elsa.Dapper.UnitTests --filter TryMarkInterrupted
  Passed!  - Failed: 0, Passed: 10, Skipped: 0

dotnet build src/modules/persistence/Elsa.Persistence.Elasticsearch
  Build succeeded (net8.0 / net9.0 / net10.0)

dotnet test test/modules/persistence/Elsa.MongoDb.UnitTests
  Passed!  - Failed: 0, Passed: 27

dotnet test test/modules/persistence/Elsa.Dapper.UnitTests
  Passed!  - Failed: 0, Passed: 16
```

`pr.yml` only triggers on PRs into `main`, so this `release/3.8.1` PR will not get that workflow.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] Targeted tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91e73477-db4f-5fc2-91c5-60b53a8ad39f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91e73477-db4f-5fc2-91c5-60b53a8ad39f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

